### PR TITLE
Feat(#10): 전체 공지사항, 마감 임박 공지 화면 및 목록 형식 선택 기능 구현

### DIFF
--- a/src/app/layouts/components/DepartmentSidebar.tsx
+++ b/src/app/layouts/components/DepartmentSidebar.tsx
@@ -42,6 +42,9 @@ export const DepartmentSidebar = () => {
     },
   ];
 
+  const currentPath = location.pathname;
+  const currentHash = location.hash;
+
   return (
     <div className="flex flex-col gap-6 pb-8">
       {/* Department Header */}
@@ -62,8 +65,14 @@ export const DepartmentSidebar = () => {
           Menu
         </span>
         {NAV_ITEMS.map((item) => {
-          const isActive =
-            location.pathname === item.path || location.hash === item.path;
+          const itemHash = item.path.includes("#")
+            ? `#${item.path.split("#")[1]}`
+            : "";
+          const itemPath = item.path.split("#")[0];
+
+          const isActive = itemHash
+            ? currentPath === itemPath && currentHash === itemHash
+            : currentPath === itemPath && currentHash === "";
 
           return (
             <Link

--- a/src/features/dashboard/components/LatestNoticeBoard.tsx
+++ b/src/features/dashboard/components/LatestNoticeBoard.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { LayoutGrid, List, Paperclip } from "lucide-react";
+import { NoticeCard } from "./NoticeCard";
+import { type Notice } from "../mockData";
+import { ROUTES } from "../../../app/router/paths";
+
+type NoticeFilter = "recent" | "deadline";
+type NoticeView = "card" | "list";
+
+interface LatestNoticeBoardProps {
+  notices: Notice[];
+  filter: NoticeFilter;
+}
+
+const parseDate = (value: string) => {
+  const parsed = Date.parse(value.replace(/\./g, "-"));
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const getFilteredNotices = (notices: Notice[], filter: NoticeFilter) => {
+  if (filter === "deadline") {
+    return notices
+      .filter((notice) => notice.dDay !== undefined)
+      .sort(
+        (a, b) =>
+          (a.dDay ?? Number.POSITIVE_INFINITY) -
+          (b.dDay ?? Number.POSITIVE_INFINITY),
+      );
+  }
+
+  return [...notices].sort((a, b) => parseDate(b.date) - parseDate(a.date));
+};
+
+export const LatestNoticeBoard = ({
+  notices,
+  filter,
+}: LatestNoticeBoardProps) => {
+  const { departmentId = "" } = useParams();
+  const [view, setView] = useState<NoticeView>("card");
+
+  const filteredNotices = useMemo(
+    () => getFilteredNotices(notices, filter),
+    [notices, filter],
+  );
+
+  const title =
+    filter === "deadline" ? "마감 임박 공지사항" : "최신 학과 공지사항";
+  const description =
+    filter === "deadline"
+      ? "마감이 가까운 공지를 우선 확인하세요."
+      : "최근 등록된 공지를 빠르게 확인하세요.";
+
+  return (
+    <section className="mt-10 scroll-mt-24">
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold tracking-[0.16em] text-emerald-700 uppercase">
+            SW CONVERGENCE COLLEGE
+          </p>
+          <h2 className="mt-1 text-3xl leading-tight font-bold tracking-tight text-slate-900">
+            {title}
+          </h2>
+          <p className="mt-2 text-sm text-slate-500">{description}</p>
+        </div>
+
+        <div className="inline-flex items-center rounded-xl border border-slate-200 bg-white p-1">
+          <button
+            type="button"
+            onClick={() => setView("card")}
+            className={`inline-flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
+              view === "card"
+                ? "bg-slate-900 text-white"
+                : "text-slate-500 hover:bg-slate-100"
+            }`}
+            aria-label="카드 보기"
+            aria-pressed={view === "card"}
+          >
+            <LayoutGrid size={18} />
+          </button>
+          <button
+            type="button"
+            onClick={() => setView("list")}
+            className={`inline-flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
+              view === "list"
+                ? "bg-slate-900 text-white"
+                : "text-slate-500 hover:bg-slate-100"
+            }`}
+            aria-label="리스트 보기"
+            aria-pressed={view === "list"}
+          >
+            <List size={18} />
+          </button>
+        </div>
+      </div>
+
+      {filteredNotices.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-6 py-12 text-center text-slate-500">
+          표시할 공지가 없습니다.
+        </div>
+      ) : view === "card" ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          {filteredNotices.map((notice) => (
+            <NoticeCard
+              key={notice.id}
+              notice={notice}
+              departmentId={departmentId}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+          {filteredNotices.map((notice, index) => (
+            <Link
+              key={notice.id}
+              to={ROUTES.noticeDetail(departmentId, notice.id)}
+              className={`group flex items-center justify-between px-5 py-4 transition-colors hover:bg-slate-50 ${
+                index < filteredNotices.length - 1
+                  ? "border-b border-slate-100"
+                  : ""
+              }`}
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="shrink-0 rounded-md bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">
+                  {notice.category}
+                </span>
+                {notice.dDay !== undefined && (
+                  <span className="shrink-0 rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white">
+                    D-{notice.dDay}
+                  </span>
+                )}
+                <span className="truncate text-sm font-medium text-slate-800 group-hover:text-[#2046FF]">
+                  {notice.title}
+                </span>
+              </div>
+
+              <div className="ml-4 flex shrink-0 items-center gap-4 text-xs text-slate-500">
+                {notice.hasAttachment && <Paperclip size={14} />}
+                <span>{notice.date}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/features/dashboard/components/LatestNoticeBoard.tsx
+++ b/src/features/dashboard/components/LatestNoticeBoard.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { LayoutGrid, List, Paperclip } from "lucide-react";
+import { Clock3, LayoutGrid, List, Paperclip } from "lucide-react";
 import { NoticeCard } from "./NoticeCard";
 import { type Notice } from "../mockData";
 import { ROUTES } from "../../../app/router/paths";
+import { getCategoryTone, isDeadlineSoon } from "../utils/noticeStyle";
 
 type NoticeFilter = "recent" | "deadline";
 type NoticeView = "card" | "list";
@@ -21,12 +22,18 @@ const parseDate = (value: string) => {
 const getFilteredNotices = (notices: Notice[], filter: NoticeFilter) => {
   if (filter === "deadline") {
     return notices
-      .filter((notice) => notice.dDay !== undefined)
-      .sort(
-        (a, b) =>
+      .filter((notice) => isDeadlineSoon(notice))
+      .sort((a, b) => {
+        const dDayGap =
           (a.dDay ?? Number.POSITIVE_INFINITY) -
-          (b.dDay ?? Number.POSITIVE_INFINITY),
-      );
+          (b.dDay ?? Number.POSITIVE_INFINITY);
+
+        if (dDayGap !== 0) {
+          return dDayGap;
+        }
+
+        return parseDate(b.date) - parseDate(a.date);
+      });
   }
 
   return [...notices].sort((a, b) => parseDate(b.date) - parseDate(a.date));
@@ -38,11 +45,26 @@ export const LatestNoticeBoard = ({
 }: LatestNoticeBoardProps) => {
   const { departmentId = "" } = useParams();
   const [view, setView] = useState<NoticeView>("card");
+  const resolvedView: NoticeView = filter === "deadline" ? "card" : view;
 
   const filteredNotices = useMemo(
     () => getFilteredNotices(notices, filter),
     [notices, filter],
   );
+  const featuredNotice = useMemo(
+    () =>
+      [...filteredNotices]
+        .filter((notice) => notice.dDay !== undefined)
+        .sort(
+          (a, b) =>
+            (a.dDay ?? Number.POSITIVE_INFINITY) -
+            (b.dDay ?? Number.POSITIVE_INFINITY),
+        )[0],
+    [filteredNotices],
+  );
+  const remainingNotices = featuredNotice
+    ? filteredNotices.filter((notice) => notice.id !== featuredNotice.id)
+    : filteredNotices;
 
   const title =
     filter === "deadline" ? "마감 임박 공지사항" : "최신 학과 공지사항";
@@ -69,12 +91,12 @@ export const LatestNoticeBoard = ({
             type="button"
             onClick={() => setView("card")}
             className={`inline-flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
-              view === "card"
+              resolvedView === "card"
                 ? "bg-slate-900 text-white"
                 : "text-slate-500 hover:bg-slate-100"
             }`}
             aria-label="카드 보기"
-            aria-pressed={view === "card"}
+            aria-pressed={resolvedView === "card"}
           >
             <LayoutGrid size={18} />
           </button>
@@ -82,12 +104,13 @@ export const LatestNoticeBoard = ({
             type="button"
             onClick={() => setView("list")}
             className={`inline-flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
-              view === "list"
+              resolvedView === "list"
                 ? "bg-slate-900 text-white"
                 : "text-slate-500 hover:bg-slate-100"
             }`}
             aria-label="리스트 보기"
-            aria-pressed={view === "list"}
+            aria-pressed={resolvedView === "list"}
+            disabled={filter === "deadline"}
           >
             <List size={18} />
           </button>
@@ -98,9 +121,46 @@ export const LatestNoticeBoard = ({
         <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-6 py-12 text-center text-slate-500">
           표시할 공지가 없습니다.
         </div>
-      ) : view === "card" ? (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          {filteredNotices.map((notice) => (
+      ) : resolvedView === "card" ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-4">
+          {featuredNotice && (
+            <Link
+              to={ROUTES.noticeDetail(departmentId, featuredNotice.id)}
+              className="group flex h-[300px] flex-col justify-between overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 transition-all hover:border-[#2046FF]/30 hover:shadow-lg hover:shadow-[#2046FF]/10 xl:col-span-2"
+            >
+              <div>
+                <div className="mb-5 flex items-center justify-between">
+                  <span
+                    className={`rounded-lg border px-3 py-1 text-xs font-bold ${getCategoryTone(featuredNotice.category)}`}
+                  >
+                    {featuredNotice.category}
+                  </span>
+                  {isDeadlineSoon(featuredNotice) && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-orange-500/10 px-3 py-1 text-xs font-bold text-orange-600">
+                      <Clock3 size={14} />
+                      D-{featuredNotice.dDay} 마감임박
+                    </span>
+                  )}
+                </div>
+
+                <h3 className="line-clamp-2 text-3xl leading-tight font-extrabold tracking-tight text-slate-900 transition-colors group-hover:text-[#2046FF]">
+                  {featuredNotice.title}
+                </h3>
+
+                <p className="mt-3 line-clamp-2 text-sm text-slate-600">
+                  {featuredNotice.summary ??
+                    "마감이 임박한 공지입니다. 자세한 내용을 확인해 제출 일정을 놓치지 마세요."}
+                </p>
+              </div>
+
+              <div className="mt-6 flex items-center gap-2 text-xs font-semibold text-slate-500">
+                <Clock3 size={14} />
+                {featuredNotice.date}
+              </div>
+            </Link>
+          )}
+
+          {remainingNotices.map((notice) => (
             <NoticeCard
               key={notice.id}
               notice={notice}
@@ -109,37 +169,70 @@ export const LatestNoticeBoard = ({
           ))}
         </div>
       ) : (
-        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
-          {filteredNotices.map((notice, index) => (
+        <div className="space-y-4">
+          {featuredNotice && (
             <Link
-              key={notice.id}
-              to={ROUTES.noticeDetail(departmentId, notice.id)}
-              className={`group flex items-center justify-between px-5 py-4 transition-colors hover:bg-slate-50 ${
-                index < filteredNotices.length - 1
-                  ? "border-b border-slate-100"
-                  : ""
-              }`}
+              to={ROUTES.noticeDetail(departmentId, featuredNotice.id)}
+              className="group block overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 transition-all hover:border-[#2046FF]/30 hover:shadow-lg hover:shadow-[#2046FF]/10"
             >
-              <div className="flex min-w-0 items-center gap-3">
-                <span className="shrink-0 rounded-md bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">
-                  {notice.category}
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <span
+                  className={`rounded-lg border px-3 py-1 text-xs font-bold ${getCategoryTone(featuredNotice.category)}`}
+                >
+                  {featuredNotice.category}
                 </span>
-                {notice.dDay !== undefined && (
-                  <span className="shrink-0 rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white">
-                    D-{notice.dDay}
+                {isDeadlineSoon(featuredNotice) && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-orange-500/10 px-3 py-1 text-xs font-bold text-orange-600">
+                    <Clock3 size={14} />
+                    D-{featuredNotice.dDay} 마감임박
                   </span>
                 )}
-                <span className="truncate text-sm font-medium text-slate-800 group-hover:text-[#2046FF]">
-                  {notice.title}
-                </span>
               </div>
-
-              <div className="ml-4 flex shrink-0 items-center gap-4 text-xs text-slate-500">
-                {notice.hasAttachment && <Paperclip size={14} />}
-                <span>{notice.date}</span>
-              </div>
+              <h3 className="line-clamp-2 text-2xl leading-tight font-extrabold text-slate-900 transition-colors group-hover:text-[#2046FF]">
+                {featuredNotice.title}
+              </h3>
+              <p className="mt-2 line-clamp-2 text-sm text-slate-600">
+                {featuredNotice.summary ??
+                  "마감이 임박한 공지입니다. 자세한 내용을 확인해 제출 일정을 놓치지 마세요."}
+              </p>
             </Link>
-          ))}
+          )}
+
+          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+            {remainingNotices.map((notice, index) => (
+              <Link
+                key={notice.id}
+                to={ROUTES.noticeDetail(departmentId, notice.id)}
+                className={`group flex items-center justify-between px-5 py-4 transition-colors hover:bg-slate-50 ${
+                  index < remainingNotices.length - 1
+                    ? "border-b border-slate-100"
+                    : ""
+                }`}
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <span
+                    className={`shrink-0 rounded-md border px-2 py-1 text-xs font-semibold ${getCategoryTone(notice.category)}`}
+                  >
+                    {notice.category}
+                  </span>
+                  {isDeadlineSoon(notice) && (
+                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white">
+                      <Clock3 size={12} />
+                      D-{notice.dDay}
+                    </span>
+                  )}
+                  <span className="truncate text-sm font-medium text-slate-800 group-hover:text-[#2046FF]">
+                    {notice.title}
+                  </span>
+                </div>
+
+                <div className="ml-4 flex shrink-0 items-center gap-4 text-xs text-slate-500">
+                  {notice.hasAttachment && <Paperclip size={14} />}
+                  <span>{notice.date}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
         </div>
       )}
     </section>

--- a/src/features/dashboard/components/LatestNoticeBoard.tsx
+++ b/src/features/dashboard/components/LatestNoticeBoard.tsx
@@ -45,7 +45,7 @@ export const LatestNoticeBoard = ({
 }: LatestNoticeBoardProps) => {
   const { departmentId = "" } = useParams();
   const [view, setView] = useState<NoticeView>("card");
-  const resolvedView: NoticeView = filter === "deadline" ? "card" : view;
+  const resolvedView = view;
 
   const filteredNotices = useMemo(
     () => getFilteredNotices(notices, filter),
@@ -110,7 +110,6 @@ export const LatestNoticeBoard = ({
             }`}
             aria-label="리스트 보기"
             aria-pressed={resolvedView === "list"}
-            disabled={filter === "deadline"}
           >
             <List size={18} />
           </button>

--- a/src/features/dashboard/components/NoticeCard.tsx
+++ b/src/features/dashboard/components/NoticeCard.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Bookmark, Clock } from "lucide-react";
 import { type Notice } from "../mockData";
 import { ROUTES } from "../../../app/router/paths";
+import { getCategoryTone, isDeadlineSoon } from "../utils/noticeStyle";
 
 interface NoticeCardProps {
   notice: Notice;
@@ -9,6 +10,8 @@ interface NoticeCardProps {
 }
 
 export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
+  const showDeadlineBadge = isDeadlineSoon(notice);
+
   return (
     <div className="group relative flex h-[300px] w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white transition-all hover:-translate-y-1 hover:border-[#2046FF]/30 hover:shadow-lg hover:shadow-[#2046FF]/10">
       <Link
@@ -22,10 +25,12 @@ export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
 
           <div className="absolute inset-0 flex flex-col justify-between p-4">
             <div className="flex items-start justify-between">
-              <span className="rounded border border-white bg-white/80 px-2 py-1 text-[11px] font-bold text-slate-700 shadow-sm backdrop-blur-sm">
+              <span
+                className={`rounded border px-2 py-1 text-[11px] font-bold shadow-sm backdrop-blur-sm ${getCategoryTone(notice.category)}`}
+              >
                 {notice.category}
               </span>
-              {notice.dDay !== undefined && (
+              {showDeadlineBadge && (
                 <span className="rounded-full bg-orange-500 px-2.5 py-1 text-[11px] font-bold text-white shadow-sm">
                   D-{notice.dDay}
                 </span>

--- a/src/features/dashboard/utils/noticeStyle.ts
+++ b/src/features/dashboard/utils/noticeStyle.ts
@@ -1,0 +1,25 @@
+import { type Notice } from "../mockData";
+
+export const DEADLINE_SOON_THRESHOLD = 5;
+
+export const isDeadlineSoon = (notice: Notice) =>
+  notice.dDay !== undefined && notice.dDay <= DEADLINE_SOON_THRESHOLD;
+
+export const getCategoryTone = (category: string) => {
+  switch (category) {
+    case "장학금":
+      return "bg-sky-100 text-sky-700 border-sky-200";
+    case "행사":
+      return "bg-emerald-100 text-emerald-700 border-emerald-200";
+    case "채용":
+    case "취업":
+      return "bg-violet-100 text-violet-700 border-violet-200";
+    case "학사":
+      return "bg-amber-100 text-amber-700 border-amber-200";
+    case "일반":
+    case "전체":
+      return "bg-slate-100 text-slate-700 border-slate-200";
+    default:
+      return "bg-slate-100 text-slate-700 border-slate-200";
+  }
+};

--- a/src/pages/dashboard/DepartmentDashboardPage.tsx
+++ b/src/pages/dashboard/DepartmentDashboardPage.tsx
@@ -1,40 +1,29 @@
+import { useLocation } from "react-router-dom";
 import { HeroBannerCarousel } from "../../features/dashboard/components/HeroBannerCarousel";
-import { NoticeSection } from "../../features/dashboard/components/NoticeSection";
+import { LatestNoticeBoard } from "../../features/dashboard/components/LatestNoticeBoard";
 import { URGENT_NOTICES, ALL_NOTICES } from "../../features/dashboard/mockData";
 
 export const DepartmentDashboardPage = () => {
+  const location = useLocation();
+  const activeFilter = location.hash === "#deadline" ? "deadline" : "recent";
+  const showHeroBanner = location.hash === "";
+
   return (
     <main className="w-full pb-20">
-      {/* 1. Hero Banner Carousel (Auto-scrolling) */}
-      <HeroBannerCarousel />
+      {showHeroBanner && <HeroBannerCarousel />}
 
-      {/* 3. Curated Notice Sections (Event-us Style) */}
-      <NoticeSection
-        title="마감 임박 공지"
-        description="시간이 얼마 남지 않았어요! 서둘러 확인하세요."
-        notices={[...URGENT_NOTICES, ...ALL_NOTICES]
-          .filter((notice) => notice.dDay !== undefined)
-          .sort(
-            (firstNotice, secondNotice) =>
-              (firstNotice.dDay ?? Number.POSITIVE_INFINITY) -
-              (secondNotice.dDay ?? Number.POSITIVE_INFINITY),
-          )
-          .slice(0, 4)}
-        viewAllLink="#deadline"
+      <div
+        id="recent"
+        className="scroll-mt-24"
+      />
+      <div
+        id="deadline"
+        className="scroll-mt-24"
       />
 
-      <NoticeSection
-        title="적극 홍보 중인 공지"
-        description="학과의 중요한 행사나 혜택을 놓치지 마세요! 🔥"
-        notices={URGENT_NOTICES}
-        viewAllLink="#urgent"
-      />
-
-      <NoticeSection
-        title="최신 등록 공지"
-        description="방금 올라온 따끈따끈한 새 소식입니다."
-        notices={ALL_NOTICES.slice(0, 4)} // Show top 4
-        viewAllLink="#recent"
+      <LatestNoticeBoard
+        notices={[...URGENT_NOTICES, ...ALL_NOTICES]}
+        filter={activeFilter}
       />
     </main>
   );

--- a/src/pages/dashboard/DepartmentDashboardPage.tsx
+++ b/src/pages/dashboard/DepartmentDashboardPage.tsx
@@ -22,6 +22,7 @@ export const DepartmentDashboardPage = () => {
       />
 
       <LatestNoticeBoard
+        key={activeFilter}
         notices={[...URGENT_NOTICES, ...ALL_NOTICES]}
         filter={activeFilter}
       />


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #10 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

1. 공지 보드 컴포넌트 재추가
- src/features/dashboard/components/LatestNoticeBoard.tsx
- 기능:
  - `recent`/`deadline` 필터 전환
  - 우측 상단 카드/리스트 뷰 토글
  - 카드 뷰는 `NoticeCard` 재사용
  - 리스트 뷰 행 렌더링 포함
  - 빈 상태 UI 포함

2. 대시보드 페이지 재수정
- src/pages/dashboard/DepartmentDashboardPage.tsx
- 변경:
  - 해시 기반 필터(`recent`/`deadline`)
  - Hero 배너는 대시보드 홈(해시 없음)에서만 표시
  - `#recent`, `#deadline` 앵커 유지
  - 기존 다중 `NoticeSection` 대신 `LatestNoticeBoard` 사용

3. 사이드바 active 로직 재수정
- src/app/layouts/components/DepartmentSidebar.tsx
- 변경:
  - 경로와 해시를 분리해 active 상태 정확히 판단
  - `#recent`, `#deadline` 메뉴 선택 반영 개선


변경 사항 적용함.
## 📸 스크린샷

- <img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/3ce3bef7-ea50-4d1e-91ce-1cd1f9f7aaac" />
- <img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/be508525-0fb8-4245-9deb-5db82816447f" />
- <img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/c3b7f8a9-cff1-4ff0-8e45-d1e21513c2ab" />




## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 마감임박 기준, 카테고리별 색 구분 결정 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 공지사항 보드 섹션 추가 (최근 순 및 마감일 순 필터링 지원)
  * 카드형/리스트형 보기 토글 기능 추가
  * 해시 기반 페이지 내 네비게이션 개선

* **Bug Fixes**
  * 사이드바 네비게이션 활성 상태 감지 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->