### PR TITLE
Feat(#13): 랜딩페이지 화면 디자인

### DIFF
--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -1,7 +1,8 @@
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { DEPARTMENTS } from "../../shared/constants/departments";
 import { ROUTES } from "../../app/router/paths";
 import { setPreferredDepartmentId } from "../../shared/hooks/usePreferredDepartment";
+import camPostLogo from "../../assets/images/CamPost_logo.png";
 
 export const LandingPage = () => {
   const navigate = useNavigate();
@@ -12,29 +13,43 @@ export const LandingPage = () => {
   };
 
   return (
-    <main className="min-h-screen bg-white p-8 text-slate-900">
-      <h1 className="mb-4 text-2xl font-bold">CamPost 랜딩 페이지입니다.</h1>
-      <p className="mb-4 text-slate-600">
-        학과를 선택하면 해당 대시보드로 이동합니다.
-      </p>
-
-      <div className="mb-8 flex flex-wrap gap-2">
-        {DEPARTMENTS.map((department) => (
-          <button
-            key={department.id}
-            type="button"
-            className="rounded border border-slate-300 px-3 py-2 text-slate-800 hover:border-[#2046FF]"
-            onClick={() => handleSelectDepartment(department.id)}
-          >
-            {department.name}
-          </button>
-        ))}
+    <main className="relative min-h-[calc(100vh-72px)] overflow-hidden bg-[#f4f7ff] px-6 py-12 text-slate-900 sm:px-8">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-16 -left-16 h-72 w-72 rounded-full bg-[#2046FF]/12 blur-3xl" />
+        <div className="absolute right-0 bottom-0 h-72 w-72 rounded-full bg-cyan-300/25 blur-3xl" />
       </div>
 
-      <div className="space-x-4 text-sm text-[#2046FF]">
-        <Link to={ROUTES.login}>로그인으로 이동</Link>
-        <Link to={ROUTES.mypage}>마이페이지(Private)로 이동</Link>
-      </div>
+      <section className="relative mx-auto flex w-full max-w-3xl flex-col items-center rounded-3xl border border-white/60 bg-white/80 px-6 py-10 shadow-[0_30px_80px_rgba(32,70,255,0.15)] backdrop-blur-xl sm:px-10 sm:py-12">
+        <p className="max-w-2xl text-center text-base leading-relaxed text-slate-600 sm:text-lg">
+          놓치기 쉬운 공지들 사이에서 정말 중요한 정보만 빠르게
+        </p>
+
+        <img
+          src={camPostLogo}
+          alt="CamPost 로고"
+          className="mt-6 h-20 w-auto object-contain opacity-95 drop-shadow-[0_8px_20px_rgba(15,23,42,0.12)] sm:h-24"
+        />
+
+        <p className="mt-6 text-center text-sm font-bold tracking-[0.12em] text-[#2046FF] uppercase">
+          학과를 선택해주세요.
+        </p>
+
+        <div className="mt-8 flex w-full max-w-md flex-col gap-3">
+          {DEPARTMENTS.map((department) => (
+            <button
+              key={department.id}
+              type="button"
+              className="group relative w-full overflow-hidden rounded-xl border border-slate-200 bg-white px-5 py-3.5 text-left transition-all hover:-translate-y-0.5 hover:border-[#2046FF]/40 hover:bg-[#f7f9ff] hover:shadow-[0_14px_30px_rgba(32,70,255,0.16)]"
+              onClick={() => handleSelectDepartment(department.id)}
+            >
+              <span className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-[#2046FF] to-cyan-400 opacity-0 transition-opacity group-hover:opacity-100" />
+              <span className="text-sm font-semibold text-slate-800 sm:text-base">
+                {department.name}
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
     </main>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #13 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 적용 결과
- 랜딩 페이지를 대시보드 톤에 맞춘 중앙 카드형 레이아웃으로 변경
- 문구는 다음 한 줄로 적용:
  - 놓치기 쉬운 공지들 사이에서 정말 중요한 정보만 빠르게
- CAMPOST 로고는 박스 없이 배경 위에 자연스럽게 배치
- 문구 복원:
  - 학과를 선택해주세요.
- 학과 버튼은 세로 정렬 + 호버 강조 스타일로 적용

수정 파일
- LandingPage.tsx

## 📸 스크린샷

- <img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/590a37f8-a149-4ff0-98be-81f149d031e4" />


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 랜딩 페이지가 새로운 배경 디자인, 로고, 그래디언트 시각 요소로 재설계되었습니다.
  * 부서 선택 버튼이 전체 너비의 카드 기반 레이아웃으로 업그레이드되었으며, 호버 효과와 그래디언트 표시기가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->