### PR TITLE
Feat(#21): 카테고리 기준 필터링 UI 구현

### DIFF
--- a/src/features/dashboard/components/LatestNoticeBoard.tsx
+++ b/src/features/dashboard/components/LatestNoticeBoard.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { Clock3, LayoutGrid, List, Paperclip } from "lucide-react";
+import { Check, Clock3, LayoutGrid, List, Paperclip, X } from "lucide-react";
 import { NoticeCard } from "./NoticeCard";
 import { ROUTES } from "../../../app/router/paths";
 import {
@@ -15,6 +15,21 @@ import type { NoticeCardData } from "../types/notice";
 type NoticeFilter = "recent" | "deadline";
 type NoticeView = "card" | "list";
 type NoticeOrder = "latest" | "oldest";
+
+const CATEGORY_ORDER = [
+  "채용정보",
+  "학사공지",
+  "행사 및 대회",
+  "장학",
+  "장학금",
+  "채용",
+  "취업",
+  "학사",
+  "행사",
+  "대회",
+  "일반",
+  "미분류",
+];
 
 interface LatestNoticeItem extends NoticeCardData {
   summary?: string;
@@ -37,6 +52,19 @@ const getFilteredNotices = (
   return [...notices];
 };
 
+const getCategoryFilteredNotices = (
+  notices: LatestNoticeItem[],
+  selectedCategories: string[],
+) => {
+  if (selectedCategories.length === 0) {
+    return notices;
+  }
+
+  return notices.filter((notice) =>
+    selectedCategories.includes(notice.category),
+  );
+};
+
 const getSortedNotices = (notices: LatestNoticeItem[], order: NoticeOrder) => {
   if (order === "oldest") {
     return [...notices].sort(
@@ -57,13 +85,45 @@ export const LatestNoticeBoard = ({
   const [view, setView] = useState<NoticeView>("card");
   const [order, setOrder] = useState<NoticeOrder>("latest");
   const [page, setPage] = useState(1);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const resolvedView = view;
   const pageSize = 12;
 
-  const filteredNotices = useMemo(
+  const filterScopedNotices = useMemo(
     () => getFilteredNotices(notices, filter),
     [notices, filter],
   );
+
+  const categoryOptions = useMemo(() => {
+    const categorySet = new Set(
+      filterScopedNotices.map((notice) => notice.category),
+    );
+
+    return [...categorySet].sort((a, b) => {
+      const aIndex = CATEGORY_ORDER.indexOf(a);
+      const bIndex = CATEGORY_ORDER.indexOf(b);
+
+      if (aIndex === -1 && bIndex === -1) {
+        return a.localeCompare(b, "ko");
+      }
+
+      if (aIndex === -1) {
+        return 1;
+      }
+
+      if (bIndex === -1) {
+        return -1;
+      }
+
+      return aIndex - bIndex;
+    });
+  }, [filterScopedNotices]);
+
+  const filteredNotices = useMemo(
+    () => getCategoryFilteredNotices(filterScopedNotices, selectedCategories),
+    [filterScopedNotices, selectedCategories],
+  );
+
   const sortedNotices = useMemo(
     () => getSortedNotices(filteredNotices, order),
     [filteredNotices, order],
@@ -81,6 +141,20 @@ export const LatestNoticeBoard = ({
       ? "마감이 가까운 공지를 우선 확인하세요."
       : "최근 등록된 공지를 빠르게 확인하세요.";
 
+  const handleCategoryToggle = (category: string) => {
+    setSelectedCategories((prevCategories) =>
+      prevCategories.includes(category)
+        ? prevCategories.filter((prevCategory) => prevCategory !== category)
+        : [...prevCategories, category],
+    );
+    setPage(1);
+  };
+
+  const handleCategoryClear = () => {
+    setSelectedCategories([]);
+    setPage(1);
+  };
+
   return (
     <section className="scroll-mt-24">
       <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
@@ -91,7 +165,46 @@ export const LatestNoticeBoard = ({
           <p className="mt-2 text-sm text-slate-500">{description}</p>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {categoryOptions.length > 0 && (
+            <div
+              className="flex flex-wrap items-center justify-end gap-1"
+              aria-label="카테고리 필터"
+            >
+              {categoryOptions.map((category) => {
+                const isSelected = selectedCategories.includes(category);
+
+                return (
+                  <button
+                    key={category}
+                    type="button"
+                    onClick={() => handleCategoryToggle(category)}
+                    className={`inline-flex h-9 items-center gap-1 rounded-lg border px-3 text-xs font-semibold transition-colors ${
+                      isSelected
+                        ? "border-[#2046FF] bg-[#2046FF] text-white"
+                        : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    {isSelected && <Check size={14} />}
+                    {category}
+                  </button>
+                );
+              })}
+
+              {selectedCategories.length > 0 && (
+                <button
+                  type="button"
+                  onClick={handleCategoryClear}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 transition-colors hover:bg-slate-50"
+                  aria-label="카테고리 필터 초기화"
+                >
+                  <X size={16} />
+                </button>
+              )}
+            </div>
+          )}
+
           <div className="inline-flex items-center rounded-xl border border-slate-200 bg-white p-1">
             <button
               type="button"

--- a/src/features/dashboard/components/LatestNoticeBoard.tsx
+++ b/src/features/dashboard/components/LatestNoticeBoard.tsx
@@ -95,9 +95,10 @@ export const LatestNoticeBoard = ({
   );
 
   const categoryOptions = useMemo(() => {
-    const categorySet = new Set(
-      filterScopedNotices.map((notice) => notice.category),
-    );
+    const categorySet = new Set([
+      ...filterScopedNotices.map((notice) => notice.category),
+      ...selectedCategories,
+    ]);
 
     return [...categorySet].sort((a, b) => {
       const aIndex = CATEGORY_ORDER.indexOf(a);
@@ -117,7 +118,7 @@ export const LatestNoticeBoard = ({
 
       return aIndex - bIndex;
     });
-  }, [filterScopedNotices]);
+  }, [filterScopedNotices, selectedCategories]);
 
   const filteredNotices = useMemo(
     () => getCategoryFilteredNotices(filterScopedNotices, selectedCategories),
@@ -166,7 +167,7 @@ export const LatestNoticeBoard = ({
         </div>
 
         <div className="flex flex-wrap items-center justify-end gap-2">
-          {categoryOptions.length > 0 && (
+          {(categoryOptions.length > 0 || selectedCategories.length > 0) && (
             <div
               className="flex flex-wrap items-center justify-end gap-1"
               aria-label="카테고리 필터"


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #21 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

API 응답으로 받은 공지들의 category 값을 모아서 필터 버튼을 자동 생성
사용자가 카테고리를 여러 개 선택하면 notice.category가 선택값에 포함된 글만 표시
선택 해제와 전체 초기화 버튼 추가
#recent, #deadline 게시판 둘 다 같은 방식으로 동작

## 📸 스크린샷

- <img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/e2d80721-08fa-4116-bd85-a02810eab85f" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공지사항 게시판의 카테고리 다중 선택 필터링 기능을 추가했습니다. 여러 카테고리를 동시에 선택하여 원하는 공지사항을 효율적으로 찾을 수 있습니다.
  * 선택된 카테고리는 체크 아이콘으로 표시되며, 초기화 버튼으로 선택을 빠르게 해제할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->