### PR TITLE
feat:회원가입 API 연동 및 에러 처리 (#27)

### DIFF
--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -183,7 +183,7 @@ export const SignupPage = () => {
         return;
       }
 
-      setCheckedUsername(result.username);
+      setCheckedUsername(normalizedUsername);
       setUsernameCheckMessage("사용 가능한 아이디입니다.");
     } catch (error) {
       setErrors((prevErrors) => ({
@@ -259,7 +259,7 @@ export const SignupPage = () => {
         return;
       }
 
-      setVerifiedEmail(result.email);
+      setVerifiedEmail(normalizedEmail);
       setEmailCodeCheckMessage("인증번호가 확인되었습니다.");
     } catch (error) {
       setErrors((prevErrors) => ({

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,8 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import type { ChangeEvent, FocusEvent, FormEvent } from "react";
 import { Link } from "react-router-dom";
 import { CheckCircle2, Loader2, UserPlus } from "lucide-react";
 import { ROUTES } from "../../app/router/paths";
+import {
+  checkEmailVerificationCode,
+  checkUsernameAvailability,
+  sendEmailVerificationCode,
+  signup,
+} from "../../shared/api/auth";
 
 type SignupForm = {
   username: string;
@@ -35,6 +41,14 @@ const usernamePattern = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{6,20}$/;
 const emailCodePattern = /^\d{6}$/;
 const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
 
+const getAuthErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
 const validateField = (
   field: keyof SignupForm,
   form: SignupForm,
@@ -47,15 +61,15 @@ const validateField = (
     return required ? requiredMessages[field] : "";
   }
 
-  if (field === "username" && !usernamePattern.test(form.username)) {
-    return "아이디는 영문과 숫자를 모두 포함해 6~20자로 입력해주세요.";
+  if (field === "username" && !usernamePattern.test(form.username.trim())) {
+    return "아이디는 영문과 숫자를 모두 포함한 6~20자로 입력해주세요.";
   }
 
-  if (field === "email" && !emailPattern.test(form.email)) {
+  if (field === "email" && !emailPattern.test(form.email.trim())) {
     return "올바른 이메일 형식으로 입력해주세요.";
   }
 
-  if (field === "emailCode" && !emailCodePattern.test(form.emailCode)) {
+  if (field === "emailCode" && !emailCodePattern.test(form.emailCode.trim())) {
     return "인증번호 6자리를 입력해주세요.";
   }
 
@@ -93,38 +107,47 @@ const validateSubmitErrors = (form: SignupForm) => {
 };
 
 export const SignupPage = () => {
-  const signupTimerRef = useRef<number | null>(null);
   const [form, setForm] = useState<SignupForm>(initialForm);
   const [errors, setErrors] = useState<SignupErrors>({});
   const [usernameCheckMessage, setUsernameCheckMessage] = useState("");
   const [emailAuthMessage, setEmailAuthMessage] = useState("");
   const [emailCodeCheckMessage, setEmailCodeCheckMessage] = useState("");
+  const [submitMessage, setSubmitMessage] = useState("");
+  const [checkedUsername, setCheckedUsername] = useState("");
+  const [verifiedEmail, setVerifiedEmail] = useState("");
+  const [isCheckingUsername, setIsCheckingUsername] = useState(false);
+  const [isSendingEmailCode, setIsSendingEmailCode] = useState(false);
+  const [isCheckingEmailCode, setIsCheckingEmailCode] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
 
-  useEffect(() => {
-    return () => {
-      if (signupTimerRef.current) {
-        window.clearTimeout(signupTimerRef.current);
-      }
-    };
-  }, []);
+  const normalizedUsername = form.username.trim();
+  const normalizedEmail = form.email.trim().toLowerCase();
+  const isUsernameChecked = checkedUsername === normalizedUsername;
+  const isEmailVerified = verifiedEmail === normalizedEmail;
 
   const handleChange =
     (field: keyof SignupForm) => (event: ChangeEvent<HTMLInputElement>) => {
-      setForm((prevForm) => ({ ...prevForm, [field]: event.target.value }));
+      const nextValue = event.target.value;
+
+      setForm((prevForm) => ({ ...prevForm, [field]: nextValue }));
       setErrors((prevErrors) => ({ ...prevErrors, [field]: undefined }));
+      setSubmitMessage("");
       setIsSubmitted(false);
 
       if (field === "username") {
+        setCheckedUsername("");
         setUsernameCheckMessage("");
       }
 
       if (field === "email") {
+        setVerifiedEmail("");
         setEmailAuthMessage("");
+        setEmailCodeCheckMessage("");
       }
 
       if (field === "emailCode") {
+        setVerifiedEmail("");
         setEmailCodeCheckMessage("");
       }
     };
@@ -137,71 +160,167 @@ export const SignupPage = () => {
       setErrors((prevErrors) => ({ ...prevErrors, [field]: fieldError }));
     };
 
-  const handleUsernameCheck = () => {
+  const handleUsernameCheck = async () => {
     const fieldError = validateField("username", form);
 
     setErrors((prevErrors) => ({ ...prevErrors, username: fieldError }));
+    setUsernameCheckMessage("");
 
-    if (!form.username.trim()) {
+    if (fieldError) {
       return;
     }
 
-    if (!fieldError) {
+    setIsCheckingUsername(true);
+
+    try {
+      const result = await checkUsernameAvailability(normalizedUsername);
+
+      if (!result.available) {
+        setErrors((prevErrors) => ({
+          ...prevErrors,
+          username: "이미 사용 중인 아이디입니다.",
+        }));
+        return;
+      }
+
+      setCheckedUsername(result.username);
       setUsernameCheckMessage("사용 가능한 아이디입니다.");
+    } catch (error) {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        username: getAuthErrorMessage(
+          error,
+          "아이디 중복 확인에 실패했습니다.",
+        ),
+      }));
+    } finally {
+      setIsCheckingUsername(false);
     }
   };
 
-  const handleEmailAuth = () => {
+  const handleEmailAuth = async () => {
     const fieldError = validateField("email", form);
 
     setErrors((prevErrors) => ({ ...prevErrors, email: fieldError }));
+    setEmailAuthMessage("");
+    setEmailCodeCheckMessage("");
+    setVerifiedEmail("");
 
-    if (!form.email.trim()) {
+    if (fieldError) {
       return;
     }
 
-    if (!fieldError) {
+    setIsSendingEmailCode(true);
+
+    try {
+      await sendEmailVerificationCode(normalizedEmail);
       setEmailAuthMessage("인증번호를 전송했습니다.");
+    } catch (error) {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        email: getAuthErrorMessage(
+          error,
+          "이메일 인증번호 전송에 실패했습니다.",
+        ),
+      }));
+    } finally {
+      setIsSendingEmailCode(false);
     }
   };
 
-  const handleEmailCodeCheck = () => {
-    const fieldError = validateField("emailCode", form);
+  const handleEmailCodeCheck = async () => {
+    const emailError = validateField("email", form);
+    const codeError = validateField("emailCode", form);
 
-    setErrors((prevErrors) => ({ ...prevErrors, emailCode: fieldError }));
+    setErrors((prevErrors) => ({
+      ...prevErrors,
+      email: emailError,
+      emailCode: codeError,
+    }));
+    setEmailCodeCheckMessage("");
 
-    if (!form.emailCode.trim()) {
+    if (emailError || codeError) {
       return;
     }
 
-    if (!fieldError) {
+    setIsCheckingEmailCode(true);
+
+    try {
+      const result = await checkEmailVerificationCode(
+        normalizedEmail,
+        form.emailCode.trim(),
+      );
+
+      if (!result.verified) {
+        setErrors((prevErrors) => ({
+          ...prevErrors,
+          emailCode: "이메일 인증번호가 유효하지 않습니다.",
+        }));
+        return;
+      }
+
+      setVerifiedEmail(result.email);
       setEmailCodeCheckMessage("인증번호가 확인되었습니다.");
+    } catch (error) {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        emailCode: getAuthErrorMessage(
+          error,
+          "이메일 인증번호 확인에 실패했습니다.",
+        ),
+      }));
+    } finally {
+      setIsCheckingEmailCode(false);
     }
   };
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const validationErrors = validateSubmitErrors(form);
+
+    if (!isUsernameChecked) {
+      validationErrors.username = "아이디 중복확인을 완료해주세요.";
+    }
+
+    if (!isEmailVerified) {
+      validationErrors.emailCode = "이메일 인증을 완료해주세요.";
+    }
+
     setErrors(validationErrors);
-    setUsernameCheckMessage("");
-    setEmailAuthMessage("");
-    setEmailCodeCheckMessage("");
+    setSubmitMessage("");
+    setIsSubmitted(false);
 
     if (Object.keys(validationErrors).length > 0) {
       return;
     }
 
-    if (signupTimerRef.current) {
-      window.clearTimeout(signupTimerRef.current);
-    }
-
     setIsSubmitting(true);
-    signupTimerRef.current = window.setTimeout(() => {
-      setIsSubmitting(false);
+
+    try {
+      await signup({
+        username: normalizedUsername,
+        email: normalizedEmail,
+        password: form.password,
+      });
       setIsSubmitted(true);
-    }, 700);
+      setSubmitMessage(
+        "회원가입이 완료되었습니다. 로그인 페이지로 이동해 주세요.",
+      );
+    } catch (error) {
+      setSubmitMessage(
+        getAuthErrorMessage(error, "회원가입 처리에 실패했습니다."),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
   };
+
+  const isAnyRequestPending =
+    isCheckingUsername ||
+    isSendingEmailCode ||
+    isCheckingEmailCode ||
+    isSubmitting;
 
   return (
     <section className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-slate-50 px-4 py-10">
@@ -233,16 +352,17 @@ export const SignupPage = () => {
                 name="username"
                 onBlur={handleBlur("username")}
                 onChange={handleChange("username")}
-                placeholder="campost_user"
+                placeholder="campost123"
                 type="text"
                 value={form.username}
               />
               <button
-                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-3 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white"
+                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-3 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
+                disabled={isAnyRequestPending}
                 onClick={handleUsernameCheck}
                 type="button"
               >
-                중복확인
+                {isCheckingUsername ? "확인 중" : "중복확인"}
               </button>
             </div>
             {errors.username && (
@@ -276,11 +396,12 @@ export const SignupPage = () => {
                 value={form.email}
               />
               <button
-                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white"
+                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
+                disabled={isAnyRequestPending}
                 onClick={handleEmailAuth}
                 type="button"
               >
-                인증
+                {isSendingEmailCode ? "전송 중" : "인증"}
               </button>
             </div>
             {errors.email && (
@@ -315,11 +436,12 @@ export const SignupPage = () => {
                 value={form.emailCode}
               />
               <button
-                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white"
+                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
+                disabled={isAnyRequestPending}
                 onClick={handleEmailCodeCheck}
                 type="button"
               >
-                확인
+                {isCheckingEmailCode ? "확인 중" : "확인"}
               </button>
             </div>
             {errors.emailCode && (
@@ -334,16 +456,20 @@ export const SignupPage = () => {
             )}
           </div>
 
-          <label className="block">
+          <label
+            className="block"
+            htmlFor="signup-password"
+          >
             <span className="mb-1.5 block text-sm font-medium text-slate-700">
               비밀번호
             </span>
             <input
               className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+              id="signup-password"
               name="password"
               onBlur={handleBlur("password")}
               onChange={handleChange("password")}
-              placeholder="8자 이상 입력"
+              placeholder="영문+숫자 포함 8자 이상"
               type="password"
               value={form.password}
             />
@@ -354,12 +480,16 @@ export const SignupPage = () => {
             )}
           </label>
 
-          <label className="block">
+          <label
+            className="block"
+            htmlFor="signup-password-confirm"
+          >
             <span className="mb-1.5 block text-sm font-medium text-slate-700">
               비밀번호 확인
             </span>
             <input
               className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+              id="signup-password-confirm"
               name="passwordConfirm"
               onBlur={handleBlur("passwordConfirm")}
               onChange={handleChange("passwordConfirm")}
@@ -376,7 +506,7 @@ export const SignupPage = () => {
 
           <button
             className="mt-2 flex h-11 w-full items-center justify-center gap-2 rounded-md bg-[#2046FF] text-sm font-semibold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
-            disabled={isSubmitting}
+            disabled={isAnyRequestPending}
             type="submit"
           >
             {isSubmitting ? (
@@ -394,13 +524,21 @@ export const SignupPage = () => {
           </button>
         </form>
 
-        {isSubmitted && (
-          <div className="mt-5 flex items-center gap-2 rounded-md bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700">
-            <CheckCircle2
-              aria-hidden="true"
-              className="h-4 w-4"
-            />
-            회원가입 정보가 정상적으로 확인되었습니다.
+        {submitMessage && (
+          <div
+            className={`mt-5 flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium ${
+              isSubmitted
+                ? "bg-emerald-50 text-emerald-700"
+                : "bg-red-50 text-red-500"
+            }`}
+          >
+            {isSubmitted && (
+              <CheckCircle2
+                aria-hidden="true"
+                className="h-4 w-4"
+              />
+            )}
+            {submitMessage}
           </div>
         )}
 

--- a/src/shared/api/auth.ts
+++ b/src/shared/api/auth.ts
@@ -1,0 +1,143 @@
+import axios, { AxiosError } from "axios";
+import { API_BASE_URL } from "../config/env";
+import type { ApiResponse } from "../types/api";
+
+const authApiClient = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10000,
+});
+
+interface ErrorResponse {
+  isSuccess: false;
+  code: string;
+  message: string;
+}
+
+interface UsernameAvailabilityResponse {
+  username: string;
+  available: boolean;
+}
+
+interface EmailVerificationCodeResponse {
+  email: string;
+  expiresAt: string;
+}
+
+interface EmailVerificationCheckResponse {
+  email: string;
+  verified: boolean;
+  verifiedAt: string;
+}
+
+interface SignupResponse {
+  username: string;
+  email: string;
+}
+
+export class AuthApiError extends Error {
+  public readonly code?: string;
+  public readonly status?: number;
+
+  constructor(message: string, code?: string, status?: number) {
+    super(message);
+    this.name = "AuthApiError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+const toAuthApiError = (error: unknown) => {
+  if (axios.isAxiosError(error)) {
+    const axiosError = error as AxiosError<ErrorResponse>;
+    const responseData = axiosError.response?.data;
+
+    return new AuthApiError(
+      responseData?.message || "요청을 처리하지 못했습니다.",
+      responseData?.code,
+      axiosError.response?.status,
+    );
+  }
+
+  if (error instanceof Error) {
+    return new AuthApiError(error.message);
+  }
+
+  return new AuthApiError("요청을 처리하지 못했습니다.");
+};
+
+const unwrapResponse = <T>(response: ApiResponse<T>) => {
+  if (!response.isSuccess) {
+    throw new AuthApiError(response.message, response.code);
+  }
+
+  return response.result;
+};
+
+export const checkUsernameAvailability = async (username: string) => {
+  try {
+    const response = await authApiClient.get<
+      ApiResponse<UsernameAvailabilityResponse>
+    >("/api/v1/auth/check-username", {
+      params: { username },
+    });
+
+    return unwrapResponse(response.data);
+  } catch (error) {
+    throw toAuthApiError(error);
+  }
+};
+
+export const sendEmailVerificationCode = async (email: string) => {
+  try {
+    const response = await authApiClient.post<
+      ApiResponse<EmailVerificationCodeResponse>
+    >("/api/v1/auth/email/verification-code", { email });
+
+    return unwrapResponse(response.data);
+  } catch (error) {
+    throw toAuthApiError(error);
+  }
+};
+
+export const checkEmailVerificationCode = async (
+  email: string,
+  code: string,
+) => {
+  try {
+    const response = await authApiClient.post<
+      ApiResponse<EmailVerificationCheckResponse>
+    >("/api/v1/auth/email/verification-code/check", {
+      email,
+      code,
+    });
+
+    return unwrapResponse(response.data);
+  } catch (error) {
+    throw toAuthApiError(error);
+  }
+};
+
+export const signup = async ({
+  username,
+  email,
+  password,
+}: {
+  username: string;
+  email: string;
+  password: string;
+}) => {
+  try {
+    const response = await authApiClient.post<ApiResponse<SignupResponse>>(
+      "/api/v1/auth/signup",
+      {
+        username,
+        email,
+        password,
+      },
+    );
+
+    return unwrapResponse(response.data);
+  } catch (error) {
+    throw toAuthApiError(error);
+  }
+};

--- a/src/shared/api/auth.ts
+++ b/src/shared/api/auth.ts
@@ -47,6 +47,10 @@ export class AuthApiError extends Error {
 }
 
 const toAuthApiError = (error: unknown) => {
+  if (error instanceof AuthApiError) {
+    return error;
+  }
+
   if (axios.isAxiosError(error)) {
     const axiosError = error as AxiosError<ErrorResponse>;
     const responseData = axiosError.response?.data;


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #27 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

## 작업 내용

- 회원가입 관련 Auth API 클라이언트를 추가했습니다.
  - 아이디 중복 확인
  - 이메일 인증번호 전송
  - 이메일 인증번호 확인
  - 최종 회원가입 요청

- 회원가입 UI에 실제 API 연동을 적용했습니다.
  - `GET /api/v1/auth/check-username`
  - `POST /api/v1/auth/email/verification-code`
  - `POST /api/v1/auth/email/verification-code/check`
  - `POST /api/v1/auth/signup`

- API 요청 상태에 따른 UI 처리를 추가했습니다.
  - 요청 중 버튼 비활성화
  - 아이디 중복 확인 중/성공/실패 메시지
  - 이메일 인증번호 전송 중/성공/실패 메시지
  - 인증번호 확인 중/성공/실패 메시지
  - 회원가입 성공/실패 메시지

- 회원가입 제출 전 필수 상태 검증을 추가했습니다.
  - 아이디 중복확인 완료 여부 확인
  - 이메일 인증 완료 여부 확인
  - 기존 클라이언트 validation 유지

- 백엔드 에러 응답 메시지를 화면에 표시하도록 처리했습니다.
  - validation 실패
  - 중복 아이디/이메일
  - 이메일 인증 실패
  - 서버 요청 실패

## 코드리뷰 반영 내용

- 아이디 중복 확인 성공 시 서버 응답의 `result.username` 대신, 검증에 사용한 `normalizedUsername`을 상태에 저장하도록 수정했습니다.
  - 서버가 아이디를 다른 대소문자로 반환해도 `isUsernameChecked` 판정이 흔들리지 않습니다.

- 이메일 인증 확인 성공 시 서버 응답의 `result.email` 대신, 검증에 사용한 `normalizedEmail`을 상태에 저장하도록 수정했습니다.
  - 서버 응답 이메일의 대소문자 차이로 `isEmailVerified` 체크가 실패하는 문제를 방지했습니다.

- `toAuthApiError`에서 `AuthApiError` 인스턴스를 먼저 확인하도록 수정했습니다.
  - `unwrapResponse`에서 발생한 `AuthApiError`의 `code`, `status` 메타데이터가 유실되지 않습니다.

## 확인

- `pnpm.cmd run build` 통과
- `pnpm.cmd run lint` 통과
- Prettier 포맷 확인


## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
