### PR TITLE
Feat(#40): 마이페이지 내 정보 API 연동 

### DIFF
--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -61,6 +61,24 @@ const formatGrade = (grade?: number | null) => {
   return grade >= 5 ? "5학년 이상" : `${grade}학년`;
 };
 
+const formatAffiliation = ({
+  departmentName,
+  gradeLabel,
+  hasDepartment,
+  hasGrade,
+}: {
+  departmentName: string;
+  gradeLabel: string;
+  hasDepartment: boolean;
+  hasGrade: boolean;
+}) => {
+  if (!hasDepartment && !hasGrade) {
+    return "소속 정보 미설정";
+  }
+
+  return `${departmentName} · ${gradeLabel}`;
+};
+
 export const MyPage = () => {
   const navigate = useNavigate();
   const { logout, userName, username } = useAuth();
@@ -117,10 +135,18 @@ export const MyPage = () => {
     profile?.nickname || profileDraft?.nickname || userName || "CamPost 사용자";
   const displayUsername = profile?.username || username || "아이디 정보 없음";
   const email = profile?.email || "이메일 정보 없음";
-  const departmentName = profile?.department
-    ? getDepartmentName(profile.department)
-    : getDepartmentName(profileDraft?.departmentCode);
-  const gradeLabel = formatGrade(profile?.grade ?? profileDraft?.grade);
+  const departmentCode = profile?.department ?? profileDraft?.departmentCode;
+  const grade = profile?.grade ?? profileDraft?.grade;
+  const hasDepartment = Boolean(departmentCode?.trim());
+  const hasGrade = Boolean(grade);
+  const departmentName = getDepartmentName(departmentCode);
+  const gradeLabel = formatGrade(grade);
+  const affiliationLabel = formatAffiliation({
+    departmentName,
+    gradeLabel,
+    hasDepartment,
+    hasGrade,
+  });
 
   const handleLogout = () => {
     logout();
@@ -148,7 +174,7 @@ export const MyPage = () => {
                   {nickname}
                 </h1>
                 <p className="mt-1 text-sm text-slate-500">
-                  {departmentName} · {gradeLabel}
+                  {affiliationLabel}
                 </p>
                 {isProfileLoading && (
                   <p className="mt-2 text-xs font-bold text-slate-400">
@@ -185,7 +211,7 @@ export const MyPage = () => {
             <ProfileFact
               icon={<GraduationCap className="h-4 w-4" />}
               label="소속"
-              value={`${departmentName} · ${gradeLabel}`}
+              value={affiliationLabel}
             />
           </div>
 

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertCircle,
   Bell,
   Bookmark,
   ChevronRight,
@@ -14,9 +15,14 @@ import {
   Trash2,
   UserRound,
 } from "lucide-react";
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ROUTES } from "../../app/router/paths";
+import {
+  getMyProfile,
+  UserApiError,
+  type UserProfileResponse,
+} from "../../shared/api/user";
 import { DEPARTMENTS } from "../../shared/constants/departments";
 import { useAuth } from "../../shared/hooks/useAuth";
 import { getOnboardingProfileDraft } from "../../shared/hooks/useOnboardingProfileDraft";
@@ -39,7 +45,15 @@ const departmentNameByCode = new Map(
 
 const PAGE_MIN_HEIGHT_CLASS = "min-h-[calc(100vh-4rem)]";
 
-const formatGrade = (grade?: number) => {
+const getDepartmentName = (department?: string | null) => {
+  if (!department?.trim()) {
+    return "학과 미설정";
+  }
+
+  return departmentNameByCode.get(department) ?? department;
+};
+
+const formatGrade = (grade?: number | null) => {
   if (!grade) {
     return "학년 미설정";
   }
@@ -51,13 +65,62 @@ export const MyPage = () => {
   const navigate = useNavigate();
   const { logout, userName, username } = useAuth();
   const profileDraft = useMemo(() => getOnboardingProfileDraft(), []);
+  const [profile, setProfile] = useState<UserProfileResponse | null>(null);
+  const [isProfileLoading, setIsProfileLoading] = useState(true);
+  const [profileErrorMessage, setProfileErrorMessage] = useState("");
 
-  const nickname = profileDraft?.nickname || userName || "CamPost 사용자";
-  const displayUsername = username || "아이디 정보 없음";
-  const departmentName = profileDraft?.departmentCode
-    ? (departmentNameByCode.get(profileDraft.departmentCode) ?? "학과 미설정")
-    : "학과 미설정";
-  const gradeLabel = formatGrade(profileDraft?.grade);
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchProfile = async () => {
+      try {
+        const myProfile = await getMyProfile();
+
+        if (!isMounted) {
+          return;
+        }
+
+        setProfile(myProfile);
+        setProfileErrorMessage("");
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+
+        const apiError =
+          error instanceof UserApiError
+            ? error
+            : new UserApiError("내 정보를 불러오지 못했습니다.");
+
+        if (apiError.status === 401) {
+          logout();
+          navigate(ROUTES.login, { replace: true });
+          return;
+        }
+
+        setProfileErrorMessage(apiError.message);
+      } finally {
+        if (isMounted) {
+          setIsProfileLoading(false);
+        }
+      }
+    };
+
+    void fetchProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [logout, navigate]);
+
+  const nickname =
+    profile?.nickname || profileDraft?.nickname || userName || "CamPost 사용자";
+  const displayUsername = profile?.username || username || "아이디 정보 없음";
+  const email = profile?.email || "이메일 정보 없음";
+  const departmentName = profile?.department
+    ? getDepartmentName(profile.department)
+    : getDepartmentName(profileDraft?.departmentCode);
+  const gradeLabel = formatGrade(profile?.grade ?? profileDraft?.grade);
 
   const handleLogout = () => {
     logout();
@@ -87,6 +150,11 @@ export const MyPage = () => {
                 <p className="mt-1 text-sm text-slate-500">
                   {departmentName} · {gradeLabel}
                 </p>
+                {isProfileLoading && (
+                  <p className="mt-2 text-xs font-bold text-slate-400">
+                    내 정보를 불러오는 중입니다.
+                  </p>
+                )}
               </div>
             </div>
 
@@ -110,16 +178,26 @@ export const MyPage = () => {
               value={displayUsername}
             />
             <ProfileFact
-              icon={<GraduationCap className="h-4 w-4" />}
-              label="소속"
-              value={departmentName}
+              icon={<Mail className="h-4 w-4" />}
+              label="이메일"
+              value={email}
             />
             <ProfileFact
-              icon={<Clock3 className="h-4 w-4" />}
-              label="학년"
-              value={gradeLabel}
+              icon={<GraduationCap className="h-4 w-4" />}
+              label="소속"
+              value={`${departmentName} · ${gradeLabel}`}
             />
           </div>
+
+          {profileErrorMessage && (
+            <div className="mt-5 flex items-start gap-2 rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-600">
+              <AlertCircle
+                aria-hidden="true"
+                className="mt-0.5 h-4 w-4 shrink-0"
+              />
+              {profileErrorMessage}
+            </div>
+          )}
         </section>
 
         <div className="mt-5 space-y-4">

--- a/src/shared/api/user.ts
+++ b/src/shared/api/user.ts
@@ -17,6 +17,36 @@ export interface OnboardingProfileResponse {
   profileCompleted: boolean;
 }
 
+export interface UserProfileResponse {
+  userId: number;
+  username: string;
+  email: string;
+  nickname: string;
+  department: string | null;
+  grade: number | null;
+  role: string;
+  profileCompleted: boolean;
+  createdAt: string;
+  lastLoginAt: string | null;
+}
+
+export const getMyProfile = async () => {
+  const accessToken = getAccessToken();
+
+  if (!accessToken) {
+    throw new ApiClientError("로그인이 필요합니다.", "TOKEN402", 401);
+  }
+
+  try {
+    const response =
+      await apiClient.get<ApiResponse<UserProfileResponse>>("/api/v1/users/me");
+
+    return unwrapResponse(response.data);
+  } catch (error) {
+    throw toApiClientError(error);
+  }
+};
+
 export const saveOnboardingProfile = async ({
   department,
   grade,


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #40 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 마이페이지에서 백엔드 내 정보 조회 API(`GET /api/v1/users/me`)를 호출하도록 연동했습니다.
- 내 정보 조회 응답 타입 `UserProfileResponse`를 추가했습니다.
- 서버에서 받은 사용자 정보를 마이페이지 프로필 영역에 표시하도록 변경했습니다.
  - 닉네임
  - 아이디
  - 이메일
  - 학과
  - 학년
- API 응답이 없거나 조회 전인 경우 기존 온보딩 draft/localStorage 값을 보조 fallback으로 사용하도록 처리했습니다.
- 내 정보 조회 중 로딩 문구를 표시하도록 추가했습니다.
- 내 정보 조회 실패 시 에러 메시지를 화면에 표시하도록 추가했습니다.
- 인증 실패(`401`) 발생 시 로그아웃 처리 후 로그인 페이지로 이동하도록 처리했습니다.

## 테스트

- `pnpm.cmd run build`
- `pnpm.cmd run lint`

## 참고

- in-app browser에서 `localhost:5173/mypage` 접근이 `net::ERR_BLOCKED_BY_CLIENT`로 차단되어 브라우저 화면 검증은 진행하지 못했습니다.

## 코드리뷰 반영 내용

- 학과와 학년이 모두 설정되지 않은 경우 별도 문구를 표시하도록 개선했습니다.
  - 기존: `학과 미설정 · 학년 미설정`
  - 변경: `소속 정보 미설정`

## 반영하지 않은 내용

- `useEffect`의 API 호출 로직을 별도 커스텀 훅으로 분리하는 제안은 이번 PR에서는 반영하지 않았습니다.
- 현재 `logout`은 `useCallback`으로 메모이제이션되어 있어 의존성 배열로 인한 불필요한 재호출 가능성이 낮습니다.
- 해당 API 호출 로직이 현재 마이페이지에서만 사용되고 있어, 별도 훅 분리는 추후 재사용 지점이 생길 때 진행하는 것이 적절하다고 판단했습니다.

## 테스트

- `pnpm.cmd run build`
- `pnpm.cmd run lint`

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
