### PR TITLE
Feat(#42): 사용자 프로필 정보 수정 UI 및 연동

### DIFF
--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -55,6 +55,10 @@ type ProfileEditForm = {
   nickname: string;
 };
 
+type CompleteProfileEditForm = Omit<ProfileEditForm, "grade"> & {
+  grade: number;
+};
+
 const departmentNameByCode = new Map(
   DEPARTMENTS.map((department) => [
     department.backendDeptCode,
@@ -110,6 +114,12 @@ const getDepartmentIdByCode = (departmentCode?: string | null) =>
   DEPARTMENTS.find(
     (department) => department.backendDeptCode === departmentCode,
   )?.id ?? "";
+
+const isProfileEditFormComplete = (
+  form: ProfileEditForm,
+  trimmedNickname: string,
+): form is CompleteProfileEditForm =>
+  Boolean(form.department) && form.grade !== "" && Boolean(trimmedNickname);
 
 export const MyPage = () => {
   const navigate = useNavigate();
@@ -193,9 +203,7 @@ export const MyPage = () => {
   );
   const trimmedEditNickname = editForm.nickname.trim();
   const canSubmitProfileEdit =
-    Boolean(editForm.department) &&
-    editForm.grade !== "" &&
-    Boolean(trimmedEditNickname) &&
+    isProfileEditFormComplete(editForm, trimmedEditNickname) &&
     !isSavingProfile;
 
   const openProfileEditForm = () => {
@@ -219,7 +227,7 @@ export const MyPage = () => {
     setEditErrorMessage("");
     setEditSuccessMessage("");
 
-    if (!canSubmitProfileEdit || editForm.grade === "") {
+    if (!isProfileEditFormComplete(editForm, trimmedEditNickname)) {
       setEditErrorMessage("닉네임, 학과, 학년을 모두 입력해주세요.");
       return;
     }
@@ -242,7 +250,7 @@ export const MyPage = () => {
       if (
         updatedDepartmentId &&
         updatedProfile.department &&
-        updatedProfile.grade
+        updatedProfile.grade != null
       ) {
         setPreferredDepartmentId(updatedDepartmentId);
         saveOnboardingProfileDraft({

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -12,28 +12,47 @@ import {
   Search,
   Settings2,
   ShieldCheck,
+  X,
   Trash2,
   UserRound,
 } from "lucide-react";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ROUTES } from "../../app/router/paths";
 import {
   getMyProfile,
+  updateMyProfile,
   UserApiError,
   type UserProfileResponse,
 } from "../../shared/api/user";
 import { DEPARTMENTS } from "../../shared/constants/departments";
 import { useAuth } from "../../shared/hooks/useAuth";
-import { getOnboardingProfileDraft } from "../../shared/hooks/useOnboardingProfileDraft";
+import {
+  getOnboardingProfileDraft,
+  saveOnboardingProfileDraft,
+} from "../../shared/hooks/useOnboardingProfileDraft";
+import { setPreferredDepartmentId } from "../../shared/hooks/usePreferredDepartment";
 
 type MenuItem = {
   title: string;
   description?: string;
   icon: ReactNode;
   to?: string;
+  onClick?: () => void;
   danger?: boolean;
   badge?: string;
+};
+
+type ProfileEditForm = {
+  department: string;
+  grade: number | "";
+  nickname: string;
 };
 
 const departmentNameByCode = new Map(
@@ -44,6 +63,14 @@ const departmentNameByCode = new Map(
 );
 
 const PAGE_MIN_HEIGHT_CLASS = "min-h-[calc(100vh-4rem)]";
+const MAX_NICKNAME_LENGTH = 50;
+const gradeOptions = [
+  { value: 1, label: "1학년" },
+  { value: 2, label: "2학년" },
+  { value: 3, label: "3학년" },
+  { value: 4, label: "4학년" },
+  { value: 5, label: "5학년 이상" },
+] as const;
 
 const getDepartmentName = (department?: string | null) => {
   if (!department?.trim()) {
@@ -79,6 +106,11 @@ const formatAffiliation = ({
   return `${departmentName} · ${gradeLabel}`;
 };
 
+const getDepartmentIdByCode = (departmentCode?: string | null) =>
+  DEPARTMENTS.find(
+    (department) => department.backendDeptCode === departmentCode,
+  )?.id ?? "";
+
 export const MyPage = () => {
   const navigate = useNavigate();
   const { logout, userName, username } = useAuth();
@@ -86,6 +118,15 @@ export const MyPage = () => {
   const [profile, setProfile] = useState<UserProfileResponse | null>(null);
   const [isProfileLoading, setIsProfileLoading] = useState(true);
   const [profileErrorMessage, setProfileErrorMessage] = useState("");
+  const [isEditingProfile, setIsEditingProfile] = useState(false);
+  const [editForm, setEditForm] = useState<ProfileEditForm>({
+    department: "",
+    grade: "",
+    nickname: "",
+  });
+  const [editErrorMessage, setEditErrorMessage] = useState("");
+  const [editSuccessMessage, setEditSuccessMessage] = useState("");
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -147,6 +188,90 @@ export const MyPage = () => {
     hasDepartment,
     hasGrade,
   });
+  const selectedEditDepartment = DEPARTMENTS.find(
+    (department) => department.backendDeptCode === editForm.department,
+  );
+  const trimmedEditNickname = editForm.nickname.trim();
+  const canSubmitProfileEdit =
+    Boolean(editForm.department) &&
+    editForm.grade !== "" &&
+    Boolean(trimmedEditNickname) &&
+    !isSavingProfile;
+
+  const openProfileEditForm = () => {
+    setEditForm({
+      department: departmentCode || "",
+      grade: grade || "",
+      nickname,
+    });
+    setEditErrorMessage("");
+    setEditSuccessMessage("");
+    setIsEditingProfile(true);
+  };
+
+  const closeProfileEditForm = () => {
+    setIsEditingProfile(false);
+    setEditErrorMessage("");
+  };
+
+  const handleProfileEditSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setEditErrorMessage("");
+    setEditSuccessMessage("");
+
+    if (!canSubmitProfileEdit || editForm.grade === "") {
+      setEditErrorMessage("닉네임, 학과, 학년을 모두 입력해주세요.");
+      return;
+    }
+
+    setIsSavingProfile(true);
+
+    try {
+      const updatedProfile = await updateMyProfile({
+        department: editForm.department,
+        grade: editForm.grade,
+        nickname: trimmedEditNickname,
+      });
+
+      setProfile(updatedProfile);
+
+      const updatedDepartmentId = getDepartmentIdByCode(
+        updatedProfile.department,
+      );
+
+      if (
+        updatedDepartmentId &&
+        updatedProfile.department &&
+        updatedProfile.grade
+      ) {
+        setPreferredDepartmentId(updatedDepartmentId);
+        saveOnboardingProfileDraft({
+          departmentId: updatedDepartmentId,
+          departmentCode: updatedProfile.department,
+          grade: updatedProfile.grade,
+          nickname: updatedProfile.nickname,
+        });
+      }
+
+      setEditSuccessMessage("프로필 정보가 저장되었습니다.");
+      setIsEditingProfile(false);
+    } catch (error) {
+      const apiError =
+        error instanceof UserApiError
+          ? error
+          : new UserApiError("프로필 정보를 저장하지 못했습니다.");
+
+      if (apiError.status === 401) {
+        logout();
+        navigate(ROUTES.login, { replace: true });
+        return;
+      }
+
+      setEditErrorMessage(apiError.message);
+    } finally {
+      setIsSavingProfile(false);
+    }
+  };
 
   const handleLogout = () => {
     logout();
@@ -224,7 +349,172 @@ export const MyPage = () => {
               {profileErrorMessage}
             </div>
           )}
+
+          {editSuccessMessage && (
+            <div className="mt-5 rounded-xl bg-[#2046FF]/10 px-4 py-3 text-sm font-bold text-[#2046FF]">
+              {editSuccessMessage}
+            </div>
+          )}
         </section>
+
+        {isEditingProfile && (
+          <section className="mt-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] sm:p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-bold text-slate-950">
+                  내 정보 수정
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  마이페이지와 공지 개인화에 사용할 정보를 수정합니다.
+                </p>
+              </div>
+
+              <button
+                aria-label="내 정보 수정 닫기"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
+                onClick={closeProfileEditForm}
+                type="button"
+              >
+                <X
+                  aria-hidden="true"
+                  className="h-4 w-4"
+                />
+              </button>
+            </div>
+
+            <form
+              className="mt-5 space-y-5"
+              noValidate
+              onSubmit={handleProfileEditSubmit}
+            >
+              <div>
+                <label
+                  className="text-sm font-bold text-slate-700"
+                  htmlFor="profile-nickname"
+                >
+                  닉네임
+                </label>
+                <input
+                  className="mt-2 h-12 w-full rounded-xl border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-950 transition outline-none placeholder:text-slate-400 focus:border-[#2046FF] focus:ring-4 focus:ring-[#2046FF]/10"
+                  id="profile-nickname"
+                  maxLength={MAX_NICKNAME_LENGTH}
+                  onChange={(event) => {
+                    setEditForm((form) => ({
+                      ...form,
+                      nickname: event.target.value,
+                    }));
+                    setEditErrorMessage("");
+                  }}
+                  placeholder="닉네임을 입력해주세요"
+                  type="text"
+                  value={editForm.nickname}
+                />
+                <div className="mt-2 flex justify-end text-xs font-semibold text-slate-400">
+                  {editForm.nickname.length}/{MAX_NICKNAME_LENGTH}
+                </div>
+              </div>
+
+              <div>
+                <p className="text-sm font-bold text-slate-700">학과</p>
+                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                  {DEPARTMENTS.map((department) => {
+                    const isSelected =
+                      department.backendDeptCode === editForm.department;
+
+                    return (
+                      <button
+                        className={`flex h-12 items-center justify-between rounded-xl border px-4 text-left text-sm font-bold transition ${
+                          isSelected
+                            ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
+                            : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                        }`}
+                        key={department.id}
+                        onClick={() => {
+                          setEditForm((form) => ({
+                            ...form,
+                            department: department.backendDeptCode,
+                          }));
+                          setEditErrorMessage("");
+                        }}
+                        type="button"
+                      >
+                        {department.name}
+                        {isSelected && (
+                          <span className="h-2 w-2 rounded-full bg-[#2046FF]" />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <p className="text-sm font-bold text-slate-700">학년</p>
+                <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-5">
+                  {gradeOptions.map((option) => {
+                    const isSelected = option.value === editForm.grade;
+
+                    return (
+                      <button
+                        className={`h-11 rounded-xl border px-3 text-sm font-bold transition ${
+                          isSelected
+                            ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
+                            : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                        }`}
+                        key={option.value}
+                        onClick={() => {
+                          setEditForm((form) => ({
+                            ...form,
+                            grade: option.value,
+                          }));
+                          setEditErrorMessage("");
+                        }}
+                        type="button"
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-500">
+                선택 정보:{" "}
+                <span className="font-bold text-slate-800">
+                  {selectedEditDepartment?.name || "학과 미선택"} ·{" "}
+                  {editForm.grade ? formatGrade(editForm.grade) : "학년 미선택"}
+                </span>
+              </div>
+
+              {editErrorMessage && (
+                <div className="flex items-start gap-2 rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-600">
+                  <AlertCircle
+                    aria-hidden="true"
+                    className="mt-0.5 h-4 w-4 shrink-0"
+                  />
+                  {editErrorMessage}
+                </div>
+              )}
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <button
+                  className="h-11 rounded-xl bg-slate-100 px-5 text-sm font-bold text-slate-700 transition hover:bg-slate-200"
+                  onClick={closeProfileEditForm}
+                  type="button"
+                >
+                  취소
+                </button>
+                <button
+                  className="h-11 rounded-xl bg-[#2046FF] px-5 text-sm font-bold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
+                  disabled={!canSubmitProfileEdit}
+                  type="submit"
+                >
+                  {isSavingProfile ? "저장 중" : "저장"}
+                </button>
+              </div>
+            </form>
+          </section>
+        )}
 
         <div className="mt-5 space-y-4">
           <MenuSection
@@ -233,7 +523,7 @@ export const MyPage = () => {
                 title: "내 정보 수정",
                 description: "닉네임, 학과, 학년",
                 icon: <Pencil className="h-5 w-5" />,
-                badge: "준비 중",
+                onClick: openProfileEditForm,
               },
               {
                 title: "비밀번호 변경",
@@ -389,7 +679,7 @@ const MenuRow = ({ item }: { item: MenuItem }) => {
         </span>
       )}
 
-      {item.to && (
+      {(item.to || item.onClick) && (
         <ChevronRight
           aria-hidden="true"
           className="h-4 w-4 shrink-0 text-slate-300"
@@ -399,16 +689,28 @@ const MenuRow = ({ item }: { item: MenuItem }) => {
   );
 
   const rowClassName = "flex w-full items-center gap-3 py-4 text-left sm:px-2";
-  const linkClassName = `${rowClassName} transition hover:bg-slate-50`;
+  const actionClassName = `${rowClassName} transition hover:bg-slate-50`;
 
   if (item.to) {
     return (
       <Link
-        className={linkClassName}
+        className={actionClassName}
         to={item.to}
       >
         {content}
       </Link>
+    );
+  }
+
+  if (item.onClick) {
+    return (
+      <button
+        className={actionClassName}
+        onClick={item.onClick}
+        type="button"
+      >
+        {content}
+      </button>
     );
   }
 

--- a/src/shared/api/user.ts
+++ b/src/shared/api/user.ts
@@ -47,6 +47,33 @@ export const getMyProfile = async () => {
   }
 };
 
+export const updateMyProfile = async ({
+  department,
+  grade,
+  nickname,
+}: {
+  department: string;
+  grade: number;
+  nickname: string;
+}) => {
+  const accessToken = getAccessToken();
+
+  if (!accessToken) {
+    throw new ApiClientError("로그인이 필요합니다.", "TOKEN402", 401);
+  }
+
+  try {
+    const response = await apiClient.patch<ApiResponse<UserProfileResponse>>(
+      "/api/v1/users/me/profile",
+      { department, grade, nickname },
+    );
+
+    return unwrapResponse(response.data);
+  } catch (error) {
+    throw toApiClientError(error);
+  }
+};
+
 export const saveOnboardingProfile = async ({
   department,
   grade,


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #42 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 사용자 프로필 수정 API 연동 함수를 추가했습니다.
  - `PATCH /api/v1/users/me/profile`
  - 수정 대상: 닉네임, 학과, 학년

- 마이페이지에서 `내 정보 수정` 메뉴를 클릭하면 프로필 수정 폼이 열리도록 구현했습니다.
  - 닉네임 입력
  - 학과 선택
  - 학년 선택
  - 선택 정보 요약 표시
  - 취소/저장 버튼 제공

- 프로필 수정 저장 시 서버 API를 호출하도록 연동했습니다.
  - 저장 성공 시 마이페이지 프로필 카드가 즉시 갱신됩니다.
  - 저장 성공 메시지를 표시합니다.
  - 저장 실패 시 서버 에러 메시지를 표시합니다.
  - 인증 실패(`401`) 시 로그아웃 후 로그인 페이지로 이동합니다.

- 프로필 수정 성공 후 로컬 개인화 정보도 함께 갱신했습니다.
  - 선호 학과 저장
  - 온보딩 프로필 draft 갱신

- 기존 마이페이지 메뉴 구조를 확장했습니다.
  - `to`가 있는 항목은 링크로 렌더링
  - `onClick`이 있는 항목은 버튼으로 렌더링
  - 동작 없는 항목은 기존처럼 비활성 표시 유지

## 변경 파일

- `src/shared/api/user.ts`
- `src/pages/mypage/MyPage.tsx`

## 테스트

- `pnpm.cmd run build`
- `pnpm.cmd run lint`

## 테스트 결과

- build 통과
- lint 통과

## 코드리뷰 반영 내용

- 프로필 수정 폼 완료 여부를 확인하는 타입 가드 함수를 추가했습니다.
  - `isProfileEditFormComplete`
  - `editForm.grade`가 숫자인 상태로 타입이 좁혀지도록 처리했습니다.

- `handleProfileEditSubmit` 내부의 중복 조건을 제거했습니다.
  - 기존: `!canSubmitProfileEdit || editForm.grade === ""`
  - 변경: `!isProfileEditFormComplete(editForm, trimmedEditNickname)`

- 업데이트된 프로필 정보를 localStorage에 동기화할 때 `grade` 체크를 명시적으로 변경했습니다.
  - 기존: `updatedProfile.grade`
  - 변경: `updatedProfile.grade != null`
  - truthy/falsy가 아니라 null 여부를 기준으로 판단하도록 개선했습니다.

## 테스트

- `pnpm.cmd run build`
- `pnpm.cmd run lint`

## 테스트 결과

- build 통과
- lint 통과
## 📸 스크린샷

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/c784a412-fe22-4b01-9390-9e5d434c026b" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [x] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
