### PR TITLE
Feat(#44): 비밀번호 변경 UI 및 연동 

### DIFF
--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -26,6 +26,7 @@ import {
 import { Link, useNavigate } from "react-router-dom";
 import { ROUTES } from "../../app/router/paths";
 import {
+  changeMyPassword,
   getMyProfile,
   updateMyProfile,
   UserApiError,
@@ -59,6 +60,12 @@ type CompleteProfileEditForm = Omit<ProfileEditForm, "grade"> & {
   grade: number;
 };
 
+type PasswordChangeForm = {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+};
+
 const departmentNameByCode = new Map(
   DEPARTMENTS.map((department) => [
     department.backendDeptCode,
@@ -68,6 +75,7 @@ const departmentNameByCode = new Map(
 
 const PAGE_MIN_HEIGHT_CLASS = "min-h-[calc(100vh-4rem)]";
 const MAX_NICKNAME_LENGTH = 50;
+const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
 const gradeOptions = [
   { value: 1, label: "1학년" },
   { value: 2, label: "2학년" },
@@ -121,6 +129,12 @@ const isProfileEditFormComplete = (
 ): form is CompleteProfileEditForm =>
   Boolean(form.department) && form.grade !== "" && Boolean(trimmedNickname);
 
+const initialPasswordChangeForm: PasswordChangeForm = {
+  currentPassword: "",
+  newPassword: "",
+  newPasswordConfirm: "",
+};
+
 export const MyPage = () => {
   const navigate = useNavigate();
   const { logout, userName, username } = useAuth();
@@ -137,6 +151,13 @@ export const MyPage = () => {
   const [editErrorMessage, setEditErrorMessage] = useState("");
   const [editSuccessMessage, setEditSuccessMessage] = useState("");
   const [isSavingProfile, setIsSavingProfile] = useState(false);
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
+  const [passwordForm, setPasswordForm] = useState<PasswordChangeForm>(
+    initialPasswordChangeForm,
+  );
+  const [passwordErrorMessage, setPasswordErrorMessage] = useState("");
+  const [passwordSuccessMessage, setPasswordSuccessMessage] = useState("");
+  const [isSavingPassword, setIsSavingPassword] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -205,8 +226,14 @@ export const MyPage = () => {
   const canSubmitProfileEdit =
     isProfileEditFormComplete(editForm, trimmedEditNickname) &&
     !isSavingProfile;
+  const canSubmitPasswordChange =
+    Boolean(passwordForm.currentPassword.trim()) &&
+    Boolean(passwordForm.newPassword.trim()) &&
+    Boolean(passwordForm.newPasswordConfirm.trim()) &&
+    !isSavingPassword;
 
   const openProfileEditForm = () => {
+    setIsChangingPassword(false);
     setEditForm({
       department: departmentCode || "",
       grade: grade || "",
@@ -217,9 +244,22 @@ export const MyPage = () => {
     setIsEditingProfile(true);
   };
 
+  const openPasswordChangeForm = () => {
+    setIsEditingProfile(false);
+    setPasswordForm(initialPasswordChangeForm);
+    setPasswordErrorMessage("");
+    setPasswordSuccessMessage("");
+    setIsChangingPassword(true);
+  };
+
   const closeProfileEditForm = () => {
     setIsEditingProfile(false);
     setEditErrorMessage("");
+  };
+
+  const closePasswordChangeForm = () => {
+    setIsChangingPassword(false);
+    setPasswordErrorMessage("");
   };
 
   const handleProfileEditSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -278,6 +318,74 @@ export const MyPage = () => {
       setEditErrorMessage(apiError.message);
     } finally {
       setIsSavingProfile(false);
+    }
+  };
+
+  const handlePasswordChangeSubmit = async (
+    event: FormEvent<HTMLFormElement>,
+  ) => {
+    event.preventDefault();
+    setPasswordErrorMessage("");
+    setPasswordSuccessMessage("");
+
+    const currentPassword = passwordForm.currentPassword;
+    const newPassword = passwordForm.newPassword;
+    const newPasswordConfirm = passwordForm.newPasswordConfirm;
+
+    if (
+      !currentPassword.trim() ||
+      !newPassword.trim() ||
+      !newPasswordConfirm.trim()
+    ) {
+      setPasswordErrorMessage(
+        "현재 비밀번호와 새 비밀번호를 모두 입력해주세요.",
+      );
+      return;
+    }
+
+    if (!passwordPattern.test(newPassword)) {
+      setPasswordErrorMessage(
+        "새 비밀번호는 영문과 숫자를 모두 포함해 8자 이상으로 입력해주세요.",
+      );
+      return;
+    }
+
+    if (newPassword !== newPasswordConfirm) {
+      setPasswordErrorMessage("새 비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    if (currentPassword === newPassword) {
+      setPasswordErrorMessage("새 비밀번호는 현재 비밀번호와 달라야 합니다.");
+      return;
+    }
+
+    setIsSavingPassword(true);
+
+    try {
+      await changeMyPassword({
+        currentPassword,
+        newPassword,
+      });
+
+      setPasswordForm(initialPasswordChangeForm);
+      setPasswordSuccessMessage("비밀번호가 변경되었습니다.");
+      setIsChangingPassword(false);
+    } catch (error) {
+      const apiError =
+        error instanceof UserApiError
+          ? error
+          : new UserApiError("비밀번호를 변경하지 못했습니다.");
+
+      if (apiError.status === 401 && apiError.code !== "AUTH401_CREDENTIALS") {
+        logout();
+        navigate(ROUTES.login, { replace: true });
+        return;
+      }
+
+      setPasswordErrorMessage(apiError.message);
+    } finally {
+      setIsSavingPassword(false);
     }
   };
 
@@ -361,6 +469,12 @@ export const MyPage = () => {
           {editSuccessMessage && (
             <div className="mt-5 rounded-xl bg-[#2046FF]/10 px-4 py-3 text-sm font-bold text-[#2046FF]">
               {editSuccessMessage}
+            </div>
+          )}
+
+          {passwordSuccessMessage && (
+            <div className="mt-5 rounded-xl bg-[#2046FF]/10 px-4 py-3 text-sm font-bold text-[#2046FF]">
+              {passwordSuccessMessage}
             </div>
           )}
         </section>
@@ -524,6 +638,115 @@ export const MyPage = () => {
           </section>
         )}
 
+        {isChangingPassword && (
+          <section className="mt-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] sm:p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-bold text-slate-950">
+                  비밀번호 변경
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다.
+                </p>
+              </div>
+
+              <button
+                aria-label="비밀번호 변경 닫기"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
+                onClick={closePasswordChangeForm}
+                type="button"
+              >
+                <X
+                  aria-hidden="true"
+                  className="h-4 w-4"
+                />
+              </button>
+            </div>
+
+            <form
+              className="mt-5 space-y-5"
+              noValidate
+              onSubmit={handlePasswordChangeSubmit}
+            >
+              <PasswordField
+                autoComplete="current-password"
+                id="current-password"
+                label="현재 비밀번호"
+                onChange={(value) => {
+                  setPasswordForm((form) => ({
+                    ...form,
+                    currentPassword: value,
+                  }));
+                  setPasswordErrorMessage("");
+                }}
+                placeholder="현재 비밀번호 입력"
+                value={passwordForm.currentPassword}
+              />
+
+              <PasswordField
+                autoComplete="new-password"
+                id="new-password"
+                label="새 비밀번호"
+                onChange={(value) => {
+                  setPasswordForm((form) => ({
+                    ...form,
+                    newPassword: value,
+                  }));
+                  setPasswordErrorMessage("");
+                }}
+                placeholder="영문+숫자 포함 8자 이상"
+                value={passwordForm.newPassword}
+              />
+
+              <PasswordField
+                autoComplete="new-password"
+                id="new-password-confirm"
+                label="새 비밀번호 확인"
+                onChange={(value) => {
+                  setPasswordForm((form) => ({
+                    ...form,
+                    newPasswordConfirm: value,
+                  }));
+                  setPasswordErrorMessage("");
+                }}
+                placeholder="새 비밀번호 재입력"
+                value={passwordForm.newPasswordConfirm}
+              />
+
+              <div className="rounded-xl bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-500">
+                새 비밀번호는 영문과 숫자를 모두 포함해 8자 이상이어야 합니다.
+              </div>
+
+              {passwordErrorMessage && (
+                <div className="flex items-start gap-2 rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-600">
+                  <AlertCircle
+                    aria-hidden="true"
+                    className="mt-0.5 h-4 w-4 shrink-0"
+                  />
+                  {passwordErrorMessage}
+                </div>
+              )}
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <button
+                  className="h-11 rounded-xl bg-slate-100 px-5 text-sm font-bold text-slate-700 transition hover:bg-slate-200"
+                  onClick={closePasswordChangeForm}
+                  type="button"
+                >
+                  취소
+                </button>
+                <button
+                  className="h-11 rounded-xl bg-[#2046FF] px-5 text-sm font-bold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
+                  disabled={!canSubmitPasswordChange}
+                  type="submit"
+                >
+                  {isSavingPassword ? "변경 중" : "변경"}
+                </button>
+              </div>
+            </form>
+          </section>
+        )}
+
         <div className="mt-5 space-y-4">
           <MenuSection
             items={[
@@ -537,7 +760,7 @@ export const MyPage = () => {
                 title: "비밀번호 변경",
                 description: "현재 비밀번호 확인 후 변경",
                 icon: <KeyRound className="h-5 w-5" />,
-                badge: "준비 중",
+                onClick: openPasswordChangeForm,
               },
               {
                 title: "이메일 설정",
@@ -630,6 +853,42 @@ const ProfileFact = ({
       {label}
     </div>
     <p className="mt-1 truncate text-sm font-bold text-slate-900">{value}</p>
+  </div>
+);
+
+const PasswordField = ({
+  id,
+  label,
+  placeholder,
+  value,
+  onChange,
+  autoComplete,
+}: {
+  id: string;
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  autoComplete: string;
+}) => (
+  <div>
+    <label
+      className="text-sm font-bold text-slate-700"
+      htmlFor={id}
+    >
+      {label}
+    </label>
+    <input
+      autoComplete={autoComplete}
+      className="mt-2 h-12 w-full rounded-xl border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-950 transition outline-none placeholder:text-slate-400 focus:border-[#2046FF] focus:ring-4 focus:ring-[#2046FF]/10"
+      id={id}
+      onChange={(event) => {
+        onChange(event.target.value);
+      }}
+      placeholder={placeholder}
+      type="password"
+      value={value}
+    />
   </div>
 );
 

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -246,6 +246,7 @@ export const MyPage = () => {
 
   const openPasswordChangeForm = () => {
     setIsEditingProfile(false);
+    setEditSuccessMessage("");
     setPasswordForm(initialPasswordChangeForm);
     setPasswordErrorMessage("");
     setPasswordSuccessMessage("");
@@ -380,6 +381,11 @@ export const MyPage = () => {
       if (apiError.status === 401 && apiError.code !== "AUTH401_CREDENTIALS") {
         logout();
         navigate(ROUTES.login, { replace: true });
+        return;
+      }
+
+      if (apiError.code === "AUTH401_CREDENTIALS") {
+        setPasswordErrorMessage("비밀번호가 올바르지 않습니다.");
         return;
       }
 

--- a/src/shared/api/user.ts
+++ b/src/shared/api/user.ts
@@ -74,6 +74,31 @@ export const updateMyProfile = async ({
   }
 };
 
+export const changeMyPassword = async ({
+  currentPassword,
+  newPassword,
+}: {
+  currentPassword: string;
+  newPassword: string;
+}) => {
+  const accessToken = getAccessToken();
+
+  if (!accessToken) {
+    throw new ApiClientError("로그인이 필요합니다.", "TOKEN402", 401);
+  }
+
+  try {
+    const response = await apiClient.patch<ApiResponse<null>>(
+      "/api/v1/users/me/password",
+      { currentPassword, newPassword },
+    );
+
+    return unwrapResponse(response.data);
+  } catch (error) {
+    throw toApiClientError(error);
+  }
+};
+
 export const saveOnboardingProfile = async ({
   department,
   grade,


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #44 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 비밀번호 변경 API 연동 함수를 추가했습니다.
  - `PATCH /api/v1/users/me/password`
  - 요청값: `currentPassword`, `newPassword`

- 마이페이지의 `비밀번호 변경` 메뉴를 실제 동작하도록 변경했습니다.
  - 기존 `준비 중` 배지 제거
  - 클릭 시 비밀번호 변경 폼 표시

- 비밀번호 변경 폼을 구현했습니다.
  - 현재 비밀번호 입력
  - 새 비밀번호 입력
  - 새 비밀번호 확인 입력
  - 취소/변경 버튼 제공

- 클라이언트 validation을 추가했습니다.
  - 필수 입력값 검증
  - 새 비밀번호 규칙 검증
    - 영문 + 숫자 포함
    - 8자 이상
  - 새 비밀번호 확인 일치 검사
  - 현재 비밀번호와 새 비밀번호 동일 여부 검사

- API 응답 처리를 추가했습니다.
  - 성공 시 폼 초기화 및 성공 메시지 표시
  - 실패 시 서버 에러 메시지 표시
  - 토큰 인증 실패 시 로그아웃 후 로그인 페이지로 이동
  - 현재 비밀번호 불일치(`AUTH401_CREDENTIALS`)는 폼 에러로 표시

- 비밀번호 입력 필드 공통 컴포넌트를 추가했습니다.
  - `PasswordField`
  - label/htmlFor/id 연결
  - `autoComplete` 속성 적용

## 변경 파일

- `src/shared/api/user.ts`
- `src/pages/mypage/MyPage.tsx`

## 테스트

- `pnpm.cmd run build`
- `pnpm.cmd run lint`

## 테스트 결과

- build 통과
- lint 통과

## 코드리뷰 반영 내용

- 비밀번호 변경 폼을 열 때 기존 프로필 수정 성공 메시지가 남지 않도록 초기화했습니다.
  - `setEditSuccessMessage("")` 추가

## 반영하지 않은 내용

- `PasswordField`를 `src/shared/components`로 분리하는 제안은 이번에는 반영하지 않았습니다.
- 현재 `PasswordField`는 마이페이지의 비밀번호 변경 폼 스타일과 상태 처리 방식에 강하게 묶여 있어, 다른 화면에서 재사용 지점이 생긴 뒤 공통 컴포넌트로 분리하는 것이 더 적절하다고 판단했습니다.

## 테스트

- `pnpm.cmd run build`
- `pnpm.cmd run lint`

## 테스트 결과

- build 통과
- lint 통과
## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
