### PR TITLE
Feat(#48): 이미지 첨부파일의 추출실패 표기 오류 개선 및 기능구현

### DIFF
--- a/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
+++ b/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   Eye,
   FileText,
+  Image,
   Paperclip,
   Share2,
 } from "lucide-react";
@@ -196,11 +197,13 @@ const AttachmentItem = ({
   ]
     .filter(Boolean)
     .join(" · ");
+  const isImage = isImageAttachment(attachment);
+  const statusLabel = getAttachmentStatusLabel(attachment);
 
   const content = (
     <>
       <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-600 group-hover:bg-white group-hover:text-[#2046FF]">
-        <FileText size={18} />
+        {isImage ? <Image size={18} /> : <FileText size={18} />}
       </span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-bold text-slate-900">
@@ -209,9 +212,9 @@ const AttachmentItem = ({
         {meta && (
           <span className="mt-1 block text-xs text-slate-500">{meta}</span>
         )}
-        {attachment.parseOk !== null && (
+        {statusLabel && (
           <span className="mt-2 block text-xs font-semibold text-slate-500">
-            {attachment.parseOk ? "본문 추출 완료" : "본문 추출 실패"}
+            {statusLabel}
           </span>
         )}
       </span>
@@ -248,6 +251,27 @@ const AttachmentItem = ({
       {content}
     </a>
   );
+};
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "bmp",
+  "svg",
+]);
+
+const isImageAttachment = (attachment: NoticeAttachmentData) =>
+  attachment.fileType?.toLowerCase() === "image" ||
+  attachment.mimeType?.toLowerCase().startsWith("image/") ||
+  IMAGE_EXTENSIONS.has(attachment.ext?.toLowerCase() ?? "");
+
+const getAttachmentStatusLabel = (attachment: NoticeAttachmentData) => {
+  if (isImageAttachment(attachment)) return "이미지 파일";
+  if (attachment.parseOk === null) return "";
+  return attachment.parseOk ? "본문 추출 완료" : "본문 추출 실패";
 };
 
 const formatFileSize = (bytes: number | null) => {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #48 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

  수정 위치: Desktop/CAMPOST/CamPost-frontend/src/features/noticeDetail/components/NoticeDetailSidebar.tsx

  변경 내용:

  - PNG/JPG 등 이미지 첨부파일은 더 이상 본문 추출 실패로 표시하지 않음
  - 이미지 첨부파일은 이미지 파일로 표시
  - 이미지 첨부에는 FileText 대신 이미지 아이콘 표시
  - HWP/PDF/DOCX/HWPX 같은 문서 첨부는 기존처럼 본문 추출 완료/실패 표시 유지

  검증:

  - pnpm lint 통과
  - pnpm format:check 통과
  - pnpm build 통과
 
## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.
<img width="289" height="611" alt="image" src="https://github.com/user-attachments/assets/54306223-1822-462b-b6d5-57dc835341bd" />



## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
