### PR TITLE
Feat(#55): 인증 상태별 헤더 및 온보딩 UX 개선

### DIFF
--- a/src/app/layouts/RootLayout.tsx
+++ b/src/app/layouts/RootLayout.tsx
@@ -1,12 +1,16 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { Header } from "./components/Header";
 import { ScrollToTop } from "../router/ScrollToTop";
+import { ROUTE_PATHS } from "../router/paths";
 
 export const RootLayout = () => {
+  const location = useLocation();
+  const shouldHideHeader = location.pathname === ROUTE_PATHS.onboardingProfile;
+
   return (
     <div className="flex min-h-screen flex-col bg-slate-50/30 font-sans text-slate-900">
       <ScrollToTop />
-      <Header />
+      {!shouldHideHeader && <Header />}
       <main className="relative flex w-full flex-1 flex-col">
         <Outlet />
       </main>

--- a/src/app/layouts/components/Header.tsx
+++ b/src/app/layouts/components/Header.tsx
@@ -23,8 +23,8 @@ export const Header = () => {
   };
 
   const handleLogout = () => {
-    logout();
     navigate(DEFAULT_PUBLIC_ENTRY_PATH, { replace: true });
+    logout();
   };
 
   return (

--- a/src/app/layouts/components/Header.tsx
+++ b/src/app/layouts/components/Header.tsx
@@ -1,55 +1,64 @@
-import { Link, useNavigate } from "react-router-dom";
-import { ROUTES } from "../../router/paths";
-import { usePreferredDepartment } from "../../../shared/hooks/usePreferredDepartment";
-import { useAuth } from "../../../shared/hooks/useAuth";
-import logoImage from "../../../assets/images/CamPost_logo.png";
 import type { MouseEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { DEFAULT_PUBLIC_ENTRY_PATH, ROUTES } from "../../router/paths";
+import logoImage from "../../../assets/images/CamPost_logo.png";
+import { useAuth } from "../../../shared/hooks/useAuth";
+import { usePreferredDepartment } from "../../../shared/hooks/usePreferredDepartment";
 
 export const Header = () => {
   const navigate = useNavigate();
   const { preferredDepartmentId } = usePreferredDepartment();
-  const { isAuthenticated, logout } = useAuth();
+  const { isAuthenticated, logout, userName, username } = useAuth();
+  const displayName = userName || username || "사용자";
 
-  const handleLogoClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
+  const handleLogoClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+
     if (preferredDepartmentId) {
       navigate(ROUTES.departmentDashboard(preferredDepartmentId));
-    } else {
-      navigate(ROUTES.home);
+      return;
     }
+
+    navigate(DEFAULT_PUBLIC_ENTRY_PATH);
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate(DEFAULT_PUBLIC_ENTRY_PATH, { replace: true });
   };
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-200/50 bg-white/80 backdrop-blur-md">
       <nav className="mx-auto flex h-16 w-full items-center justify-between px-6 text-sm lg:px-8">
-        <div className="flex items-center gap-8">
-          <a
-            href="/"
-            onClick={handleLogoClick}
-            className="flex items-center gap-2 text-xl font-bold tracking-tight transition-opacity"
-          >
-            <img
-              src={logoImage}
-              alt="CamPost Logo"
-              className="h-8 w-auto object-contain"
-            />
-          </a>
-        </div>
+        <a
+          className="flex items-center gap-2 text-xl font-bold tracking-tight transition-opacity"
+          href="/"
+          onClick={handleLogoClick}
+        >
+          <img
+            alt="CamPost Logo"
+            className="h-8 w-auto object-contain"
+            src={logoImage}
+          />
+        </a>
 
-        <div className="flex items-center gap-6 font-medium">
-          <Link
-            className="text-slate-600 transition-colors hover:text-[#2046FF]"
-            to={ROUTES.mypage}
-          >
-            마이페이지
-          </Link>
+        <div className="flex items-center gap-5 font-medium">
           {isAuthenticated ? (
-            <button
-              onClick={logout}
-              className="rounded-full bg-slate-100 px-4 py-2 text-slate-700 transition-all hover:bg-slate-200 active:scale-95"
-            >
-              로그아웃
-            </button>
+            <>
+              <Link
+                className="text-slate-700 transition-colors hover:text-[#2046FF]"
+                to={ROUTES.mypage}
+              >
+                {displayName}님
+              </Link>
+              <button
+                className="rounded-full bg-slate-100 px-4 py-2 text-slate-700 transition-all hover:bg-slate-200 active:scale-95"
+                onClick={handleLogout}
+                type="button"
+              >
+                로그아웃
+              </button>
+            </>
           ) : (
             <Link
               className="rounded-full bg-linear-to-r from-[#2046FF] to-[#4064FF] px-5 py-2 text-white shadow-md shadow-[#2046FF]/20 transition-all hover:shadow-lg hover:shadow-[#2046FF]/30 active:scale-95"

--- a/src/app/layouts/components/Header.tsx
+++ b/src/app/layouts/components/Header.tsx
@@ -32,7 +32,7 @@ export const Header = () => {
       <nav className="mx-auto flex h-16 w-full items-center justify-between px-6 text-sm lg:px-8">
         <a
           className="flex items-center gap-2 text-xl font-bold tracking-tight transition-opacity"
-          href="/"
+          href={DEFAULT_PUBLIC_ENTRY_PATH}
           onClick={handleLogoClick}
         >
           <img

--- a/src/pages/onboarding/OnboardingProfilePage.tsx
+++ b/src/pages/onboarding/OnboardingProfilePage.tsx
@@ -297,7 +297,7 @@ export const OnboardingProfilePage = () => {
           onClick={handleSkip}
           type="button"
         >
-          다음에 설정하기
+          나중에 설정하기
         </button>
       </form>
     </section>

--- a/src/pages/onboarding/OnboardingProfilePage.tsx
+++ b/src/pages/onboarding/OnboardingProfilePage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { Check, ChevronLeft } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { ROUTES } from "../../app/router/paths";
+import { DEFAULT_PUBLIC_ENTRY_PATH, ROUTES } from "../../app/router/paths";
 import { saveOnboardingProfile, UserApiError } from "../../shared/api/user";
 import {
   DEPARTMENTS,
@@ -60,6 +60,10 @@ export const OnboardingProfilePage = () => {
     setCurrentStep((step) => Math.min(step + 1, steps.length - 1));
   };
 
+  const handleSkip = () => {
+    navigate(DEFAULT_PUBLIC_ENTRY_PATH, { replace: true });
+  };
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setNicknameTouched(true);
@@ -104,7 +108,7 @@ export const OnboardingProfilePage = () => {
   };
 
   return (
-    <section className="min-h-[calc(100vh-4rem)] bg-[#f5f7fb] px-5 py-8 text-slate-950 sm:px-8 sm:py-12">
+    <section className="min-h-screen bg-[#f5f7fb] px-5 py-8 text-slate-950 sm:px-8 sm:py-12">
       <form
         className="mx-auto flex min-h-[680px] w-full max-w-[520px] flex-col rounded-[28px] bg-white px-6 py-6 shadow-[0_24px_70px_rgba(15,23,42,0.10)] sm:px-8"
         noValidate
@@ -287,6 +291,13 @@ export const OnboardingProfilePage = () => {
           type={currentStep < steps.length - 1 ? "button" : "submit"}
         >
           {currentStep < steps.length - 1 ? "다음" : "완료"}
+        </button>
+        <button
+          className="mt-3 h-9 text-sm font-semibold text-slate-400 transition hover:text-slate-600"
+          onClick={handleSkip}
+          type="button"
+        >
+          다음에 설정하기
         </button>
       </form>
     </section>


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #55 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 로그인 상태 헤더 UX 개선
  - 로그인 상태일 때 `OOO님` 표시
  - `OOO님` 클릭 시 마이페이지 이동
  - 로그아웃 버튼 클릭 시 인증 정보 초기화 후 초기 화면으로 이동
  - 초기 화면 이동은 임시 소프트웨어학과 공지 페이지를 가리키는 `DEFAULT_PUBLIC_ENTRY_PATH` 사용

- 비로그인 상태 헤더 정리
  - 비로그인 상태에서는 로그인 버튼만 표시

- 온보딩 화면 헤더 숨김 처리
  - `/onboarding/profile`에서는 CamPost 로고, 마이페이지, 로그아웃 버튼이 보이지 않도록 처리

- 온보딩 건너뛰기 UX 추가
  - `다음` / `완료` 버튼 아래에 `다음에 설정하기` 버튼 추가
  - 클릭 시 초기 화면으로 이동
  - 온보딩 페이지는 헤더가 없으므로 `min-h-screen` 기준으로 화면 높이 조정

- 로그아웃 처리 순서 변경
  - 기존: `logout()` → `navigate(DEFAULT_PUBLIC_ENTRY_PATH)`
  - 변경: `navigate(DEFAULT_PUBLIC_ENTRY_PATH)` → `logout()`
- 보호 라우트에서 로그인 페이지로 먼저 리다이렉트되는 깜빡임 가능성을 줄이도록 개선

- Header 로고 앵커의 `href`를 `/`에서 `DEFAULT_PUBLIC_ENTRY_PATH`로 변경
- 새 탭 열기 / 중간 클릭 시에도 임시 초기 화면인 소프트웨어학과 공지 페이지로 이동하도록 일관성 개선
## 📸 스크린샷

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/e38572e9-6084-41d3-9def-e70dfddc07e8" />
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/3b166508-7576-4a83-99d0-638dee526fb0" />


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 온보딩 프로필 설정 건너뛰기 옵션 추가

* **개선 사항**
  * 온보딩 프로필 페이지에서 헤더 숨김 처리
  * 로그아웃 후 자동 페이지 이동 추가
  * 인증 상태에 따른 헤더 메뉴 UI 조정
  * 마이페이지 링크에 사용자명 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-frontend/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->