### PR TITLE
Feat(#57): 회원가입 완료 및 이메일 인증 에러 UX 개선

### DIFF
--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { CheckCircle2, Loader2, UserPlus } from "lucide-react";
 import { ROUTES } from "../../app/router/paths";
 import {
+  AuthApiError,
   checkEmailVerificationCode,
   checkUsernameAvailability,
   sendEmailVerificationCode,
@@ -261,7 +262,7 @@ export const SignupPage = () => {
       if (!result.verified) {
         setErrors((prevErrors) => ({
           ...prevErrors,
-          emailCode: "이메일 인증번호가 유효하지 않습니다.",
+          emailCode: "인증번호가 일치하지 않습니다.",
         }));
         return;
       }
@@ -269,6 +270,17 @@ export const SignupPage = () => {
       setVerifiedEmail(normalizedEmail);
       setEmailCodeCheckMessage("인증번호가 확인되었습니다.");
     } catch (error) {
+      if (
+        error instanceof AuthApiError &&
+        error.code === "AUTH400_EMAIL_VERIFICATION"
+      ) {
+        setErrors((prevErrors) => ({
+          ...prevErrors,
+          emailCode: "인증번호가 일치하지 않습니다.",
+        }));
+        return;
+      }
+
       setErrors((prevErrors) => ({
         ...prevErrors,
         emailCode: getAuthErrorMessage(
@@ -312,9 +324,7 @@ export const SignupPage = () => {
         password: form.password,
       });
       setIsSubmitted(true);
-      setSubmitMessage(
-        "회원가입이 완료되었습니다. 로그인 페이지로 이동해 주세요.",
-      );
+      setSubmitMessage("");
     } catch (error) {
       setSubmitMessage(
         getAuthErrorMessage(error, "회원가입 처리에 실패했습니다."),
@@ -329,6 +339,35 @@ export const SignupPage = () => {
     isSendingEmailCode ||
     isCheckingEmailCode ||
     isSubmitting;
+
+  if (isSubmitted) {
+    return (
+      <section className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-slate-50 px-4 py-10">
+        <div className="shadow-soft w-full max-w-[440px] rounded-lg border border-slate-200 bg-white p-8 text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
+            <CheckCircle2
+              aria-hidden="true"
+              className="h-7 w-7"
+            />
+          </div>
+
+          <h1 className="mt-5 text-2xl font-bold text-slate-950">
+            회원가입이 완료되었습니다.
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-slate-500">
+            로그인 후 CamPost에서 필요한 공지를 확인해보세요.
+          </p>
+
+          <Link
+            className="mt-7 flex h-11 w-full items-center justify-center rounded-md bg-[#2046FF] text-sm font-semibold text-white transition hover:bg-[#1838d8]"
+            to={ROUTES.login}
+          >
+            로그인
+          </Link>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-slate-50 px-4 py-10">

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -44,6 +44,7 @@ const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const usernamePattern = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{6,20}$/;
 const emailCodePattern = /^\d{6}$/;
 const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
+const ERROR_INVALID_EMAIL_CODE = "인증번호가 일치하지 않습니다.";
 
 const getAuthErrorMessage = (error: unknown, fallback: string) => {
   if (error instanceof Error && error.message) {
@@ -262,7 +263,7 @@ export const SignupPage = () => {
       if (!result.verified) {
         setErrors((prevErrors) => ({
           ...prevErrors,
-          emailCode: "인증번호가 일치하지 않습니다.",
+          emailCode: ERROR_INVALID_EMAIL_CODE,
         }));
         return;
       }
@@ -276,7 +277,7 @@ export const SignupPage = () => {
       ) {
         setErrors((prevErrors) => ({
           ...prevErrors,
-          emailCode: "인증번호가 일치하지 않습니다.",
+          emailCode: ERROR_INVALID_EMAIL_CODE,
         }));
         return;
       }
@@ -340,288 +341,292 @@ export const SignupPage = () => {
     isCheckingEmailCode ||
     isSubmitting;
 
-  if (isSubmitted) {
-    return (
-      <section className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-slate-50 px-4 py-10">
-        <div className="shadow-soft w-full max-w-[440px] rounded-lg border border-slate-200 bg-white p-8 text-center">
-          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
-            <CheckCircle2
-              aria-hidden="true"
-              className="h-7 w-7"
-            />
-          </div>
-
-          <h1 className="mt-5 text-2xl font-bold text-slate-950">
-            회원가입이 완료되었습니다.
-          </h1>
-          <p className="mt-3 text-sm leading-6 text-slate-500">
-            로그인 후 CamPost에서 필요한 공지를 확인해보세요.
-          </p>
-
-          <Link
-            className="mt-7 flex h-11 w-full items-center justify-center rounded-md bg-[#2046FF] text-sm font-semibold text-white transition hover:bg-[#1838d8]"
-            to={ROUTES.login}
-          >
-            로그인
-          </Link>
-        </div>
-      </section>
-    );
-  }
-
   return (
     <section className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-slate-50 px-4 py-10">
-      <div className="shadow-soft w-full max-w-[440px] rounded-lg border border-slate-200 bg-white p-8">
-        <div className="mb-7">
-          <p className="mb-2 text-sm font-semibold text-[#2046FF]">CamPost</p>
-          <h1 className="text-2xl font-bold text-slate-950">회원가입</h1>
-          <p className="mt-2 text-sm text-slate-500">
-            계정 정보를 입력하고 CamPost를 시작하세요.
-          </p>
-        </div>
-
-        <form
-          className="space-y-4"
-          noValidate
-          onSubmit={handleSubmit}
-        >
-          <div>
-            <label
-              className="mb-1.5 block text-sm font-medium text-slate-700"
-              htmlFor="signup-name"
-            >
-              이름
-            </label>
-            <input
-              className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
-              id="signup-name"
-              name="name"
-              onBlur={handleBlur("name")}
-              onChange={handleChange("name")}
-              placeholder="홍길동"
-              type="text"
-              value={form.name}
-            />
-            {errors.name && (
-              <span className="mt-1.5 block text-xs font-medium text-red-500">
-                {errors.name}
-              </span>
-            )}
-          </div>
-
-          <div>
-            <label
-              className="mb-1.5 block text-sm font-medium text-slate-700"
-              htmlFor="signup-username"
-            >
-              아이디
-            </label>
-            <div className="flex gap-2">
-              <input
-                className="h-11 min-w-0 flex-1 rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
-                id="signup-username"
-                name="username"
-                onBlur={handleBlur("username")}
-                onChange={handleChange("username")}
-                placeholder="campost123"
-                type="text"
-                value={form.username}
-              />
-              <button
-                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-3 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
-                disabled={isAnyRequestPending}
-                onClick={handleUsernameCheck}
-                type="button"
-              >
-                {isCheckingUsername ? "확인 중" : "중복확인"}
-              </button>
-            </div>
-            {errors.username && (
-              <span className="mt-1.5 block text-xs font-medium text-red-500">
-                {errors.username}
-              </span>
-            )}
-            {usernameCheckMessage && !errors.username && (
-              <span className="mt-1.5 block text-xs font-medium text-emerald-600">
-                {usernameCheckMessage}
-              </span>
-            )}
-          </div>
-
-          <div>
-            <label
-              className="mb-1.5 block text-sm font-medium text-slate-700"
-              htmlFor="signup-email"
-            >
-              이메일
-            </label>
-            <div className="flex gap-2">
-              <input
-                className="h-11 min-w-0 flex-1 rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
-                id="signup-email"
-                name="email"
-                onBlur={handleBlur("email")}
-                onChange={handleChange("email")}
-                placeholder="campost@example.com"
-                type="email"
-                value={form.email}
-              />
-              <button
-                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
-                disabled={isAnyRequestPending}
-                onClick={handleEmailAuth}
-                type="button"
-              >
-                {isSendingEmailCode ? "전송 중" : "인증"}
-              </button>
-            </div>
-            {errors.email && (
-              <span className="mt-1.5 block text-xs font-medium text-red-500">
-                {errors.email}
-              </span>
-            )}
-            {emailAuthMessage && !errors.email && (
-              <span className="mt-1.5 block text-xs font-medium text-emerald-600">
-                {emailAuthMessage}
-              </span>
-            )}
-          </div>
-
-          <div>
-            <label
-              className="mb-1.5 block text-sm font-medium text-slate-700"
-              htmlFor="signup-email-code"
-            >
-              이메일 인증번호
-            </label>
-            <div className="flex gap-2">
-              <input
-                className="h-11 min-w-0 flex-1 rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
-                id="signup-email-code"
-                inputMode="numeric"
-                name="emailCode"
-                onBlur={handleBlur("emailCode")}
-                onChange={handleChange("emailCode")}
-                placeholder="인증번호 6자리"
-                type="text"
-                value={form.emailCode}
-              />
-              <button
-                className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
-                disabled={isAnyRequestPending}
-                onClick={handleEmailCodeCheck}
-                type="button"
-              >
-                {isCheckingEmailCode ? "확인 중" : "확인"}
-              </button>
-            </div>
-            {errors.emailCode && (
-              <span className="mt-1.5 block text-xs font-medium text-red-500">
-                {errors.emailCode}
-              </span>
-            )}
-            {emailCodeCheckMessage && !errors.emailCode && (
-              <span className="mt-1.5 block text-xs font-medium text-emerald-600">
-                {emailCodeCheckMessage}
-              </span>
-            )}
-          </div>
-
-          <label
-            className="block"
-            htmlFor="signup-password"
-          >
-            <span className="mb-1.5 block text-sm font-medium text-slate-700">
-              비밀번호
-            </span>
-            <input
-              className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
-              id="signup-password"
-              name="password"
-              onBlur={handleBlur("password")}
-              onChange={handleChange("password")}
-              placeholder="영문+숫자 포함 8자 이상"
-              type="password"
-              value={form.password}
-            />
-            {errors.password && (
-              <span className="mt-1.5 block text-xs font-medium text-red-500">
-                {errors.password}
-              </span>
-            )}
-          </label>
-
-          <label
-            className="block"
-            htmlFor="signup-password-confirm"
-          >
-            <span className="mb-1.5 block text-sm font-medium text-slate-700">
-              비밀번호 확인
-            </span>
-            <input
-              className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
-              id="signup-password-confirm"
-              name="passwordConfirm"
-              onBlur={handleBlur("passwordConfirm")}
-              onChange={handleChange("passwordConfirm")}
-              placeholder="비밀번호 재입력"
-              type="password"
-              value={form.passwordConfirm}
-            />
-            {errors.passwordConfirm && (
-              <span className="mt-1.5 block text-xs font-medium text-red-500">
-                {errors.passwordConfirm}
-              </span>
-            )}
-          </label>
-
-          <button
-            className="mt-2 flex h-11 w-full items-center justify-center gap-2 rounded-md bg-[#2046FF] text-sm font-semibold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
-            disabled={isAnyRequestPending}
-            type="submit"
-          >
-            {isSubmitting ? (
-              <Loader2
-                aria-hidden="true"
-                className="h-4 w-4 animate-spin"
-              />
-            ) : (
-              <UserPlus
-                aria-hidden="true"
-                className="h-4 w-4"
-              />
-            )}
-            {isSubmitting ? "가입 처리 중" : "회원가입"}
-          </button>
-        </form>
-
-        {submitMessage && (
-          <div
-            className={`mt-5 flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium ${
-              isSubmitted
-                ? "bg-emerald-50 text-emerald-700"
-                : "bg-red-50 text-red-500"
-            }`}
-          >
-            {isSubmitted && (
+      <div
+        className={`shadow-soft w-full max-w-[440px] rounded-lg border border-slate-200 bg-white p-8 ${
+          isSubmitted ? "text-center" : ""
+        }`}
+      >
+        {isSubmitted ? (
+          <>
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
               <CheckCircle2
                 aria-hidden="true"
-                className="h-4 w-4"
+                className="h-7 w-7"
               />
-            )}
-            {submitMessage}
-          </div>
-        )}
+            </div>
 
-        <p className="mt-6 text-center text-sm text-slate-500">
-          이미 계정이 있으신가요?{" "}
-          <Link
-            className="font-semibold text-[#2046FF] hover:underline"
-            to={ROUTES.login}
-          >
-            로그인
-          </Link>
-        </p>
+            <h1 className="mt-5 text-2xl font-bold text-slate-950">
+              회원가입이 완료되었습니다.
+            </h1>
+            <p className="mt-3 text-sm leading-6 text-slate-500">
+              로그인 후 CamPost에서 필요한 공지를 확인해보세요.
+            </p>
+
+            <Link
+              className="mt-7 flex h-11 w-full items-center justify-center rounded-md bg-[#2046FF] text-sm font-semibold text-white transition hover:bg-[#1838d8]"
+              to={ROUTES.login}
+            >
+              로그인
+            </Link>
+          </>
+        ) : (
+          <>
+            <div className="mb-7">
+              <p className="mb-2 text-sm font-semibold text-[#2046FF]">
+                CamPost
+              </p>
+              <h1 className="text-2xl font-bold text-slate-950">회원가입</h1>
+              <p className="mt-2 text-sm text-slate-500">
+                계정 정보를 입력하고 CamPost를 시작하세요.
+              </p>
+            </div>
+
+            <form
+              className="space-y-4"
+              noValidate
+              onSubmit={handleSubmit}
+            >
+              <div>
+                <label
+                  className="mb-1.5 block text-sm font-medium text-slate-700"
+                  htmlFor="signup-name"
+                >
+                  이름
+                </label>
+                <input
+                  className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+                  id="signup-name"
+                  name="name"
+                  onBlur={handleBlur("name")}
+                  onChange={handleChange("name")}
+                  placeholder="홍길동"
+                  type="text"
+                  value={form.name}
+                />
+                {errors.name && (
+                  <span className="mt-1.5 block text-xs font-medium text-red-500">
+                    {errors.name}
+                  </span>
+                )}
+              </div>
+
+              <div>
+                <label
+                  className="mb-1.5 block text-sm font-medium text-slate-700"
+                  htmlFor="signup-username"
+                >
+                  아이디
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    className="h-11 min-w-0 flex-1 rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+                    id="signup-username"
+                    name="username"
+                    onBlur={handleBlur("username")}
+                    onChange={handleChange("username")}
+                    placeholder="campost123"
+                    type="text"
+                    value={form.username}
+                  />
+                  <button
+                    className="h-11 shrink-0 rounded-md border border-[#2046FF] px-3 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
+                    disabled={isAnyRequestPending}
+                    onClick={handleUsernameCheck}
+                    type="button"
+                  >
+                    {isCheckingUsername ? "확인 중" : "중복확인"}
+                  </button>
+                </div>
+                {errors.username && (
+                  <span className="mt-1.5 block text-xs font-medium text-red-500">
+                    {errors.username}
+                  </span>
+                )}
+                {usernameCheckMessage && !errors.username && (
+                  <span className="mt-1.5 block text-xs font-medium text-emerald-600">
+                    {usernameCheckMessage}
+                  </span>
+                )}
+              </div>
+
+              <div>
+                <label
+                  className="mb-1.5 block text-sm font-medium text-slate-700"
+                  htmlFor="signup-email"
+                >
+                  이메일
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    className="h-11 min-w-0 flex-1 rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+                    id="signup-email"
+                    name="email"
+                    onBlur={handleBlur("email")}
+                    onChange={handleChange("email")}
+                    placeholder="campost@example.com"
+                    type="email"
+                    value={form.email}
+                  />
+                  <button
+                    className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
+                    disabled={isAnyRequestPending}
+                    onClick={handleEmailAuth}
+                    type="button"
+                  >
+                    {isSendingEmailCode ? "전송 중" : "인증"}
+                  </button>
+                </div>
+                {errors.email && (
+                  <span className="mt-1.5 block text-xs font-medium text-red-500">
+                    {errors.email}
+                  </span>
+                )}
+                {emailAuthMessage && !errors.email && (
+                  <span className="mt-1.5 block text-xs font-medium text-emerald-600">
+                    {emailAuthMessage}
+                  </span>
+                )}
+              </div>
+
+              <div>
+                <label
+                  className="mb-1.5 block text-sm font-medium text-slate-700"
+                  htmlFor="signup-email-code"
+                >
+                  이메일 인증번호
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    className="h-11 min-w-0 flex-1 rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+                    id="signup-email-code"
+                    inputMode="numeric"
+                    name="emailCode"
+                    onBlur={handleBlur("emailCode")}
+                    onChange={handleChange("emailCode")}
+                    placeholder="인증번호 6자리"
+                    type="text"
+                    value={form.emailCode}
+                  />
+                  <button
+                    className="h-11 shrink-0 rounded-md border border-[#2046FF] px-4 text-sm font-semibold text-[#2046FF] transition hover:bg-[#2046FF] hover:text-white disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400 disabled:hover:bg-white"
+                    disabled={isAnyRequestPending}
+                    onClick={handleEmailCodeCheck}
+                    type="button"
+                  >
+                    {isCheckingEmailCode ? "확인 중" : "확인"}
+                  </button>
+                </div>
+                {errors.emailCode && (
+                  <span className="mt-1.5 block text-xs font-medium text-red-500">
+                    {errors.emailCode}
+                  </span>
+                )}
+                {emailCodeCheckMessage && !errors.emailCode && (
+                  <span className="mt-1.5 block text-xs font-medium text-emerald-600">
+                    {emailCodeCheckMessage}
+                  </span>
+                )}
+              </div>
+
+              <label
+                className="block"
+                htmlFor="signup-password"
+              >
+                <span className="mb-1.5 block text-sm font-medium text-slate-700">
+                  비밀번호
+                </span>
+                <input
+                  className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+                  id="signup-password"
+                  name="password"
+                  onBlur={handleBlur("password")}
+                  onChange={handleChange("password")}
+                  placeholder="영문+숫자 포함 8자 이상"
+                  type="password"
+                  value={form.password}
+                />
+                {errors.password && (
+                  <span className="mt-1.5 block text-xs font-medium text-red-500">
+                    {errors.password}
+                  </span>
+                )}
+              </label>
+
+              <label
+                className="block"
+                htmlFor="signup-password-confirm"
+              >
+                <span className="mb-1.5 block text-sm font-medium text-slate-700">
+                  비밀번호 확인
+                </span>
+                <input
+                  className="h-11 w-full rounded-md border border-slate-300 px-3 text-sm transition outline-none focus:border-[#2046FF] focus:ring-2 focus:ring-[#2046FF]/15"
+                  id="signup-password-confirm"
+                  name="passwordConfirm"
+                  onBlur={handleBlur("passwordConfirm")}
+                  onChange={handleChange("passwordConfirm")}
+                  placeholder="비밀번호 재입력"
+                  type="password"
+                  value={form.passwordConfirm}
+                />
+                {errors.passwordConfirm && (
+                  <span className="mt-1.5 block text-xs font-medium text-red-500">
+                    {errors.passwordConfirm}
+                  </span>
+                )}
+              </label>
+
+              <button
+                className="mt-2 flex h-11 w-full items-center justify-center gap-2 rounded-md bg-[#2046FF] text-sm font-semibold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
+                disabled={isAnyRequestPending}
+                type="submit"
+              >
+                {isSubmitting ? (
+                  <Loader2
+                    aria-hidden="true"
+                    className="h-4 w-4 animate-spin"
+                  />
+                ) : (
+                  <UserPlus
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                  />
+                )}
+                {isSubmitting ? "가입 처리 중" : "회원가입"}
+              </button>
+            </form>
+
+            {submitMessage && (
+              <div
+                className={`mt-5 flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium ${
+                  isSubmitted
+                    ? "bg-emerald-50 text-emerald-700"
+                    : "bg-red-50 text-red-500"
+                }`}
+              >
+                {isSubmitted && (
+                  <CheckCircle2
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                  />
+                )}
+                {submitMessage}
+              </div>
+            )}
+
+            <p className="mt-6 text-center text-sm text-slate-500">
+              이미 계정이 있으신가요?{" "}
+              <Link
+                className="font-semibold text-[#2046FF] hover:underline"
+                to={ROUTES.login}
+              >
+                로그인
+              </Link>
+            </p>
+          </>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #57 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 회원가입 성공 후 완료 화면 추가
  - 기존처럼 폼 하단에 성공 메시지를 띄우지 않고, 완료 전용 화면으로 전환
  - `회원가입이 완료되었습니다.` 문구 표시
  - 안내 문구와 함께 `로그인` 버튼 제공
  - 로그인 버튼 클릭 시 `/login`으로 이동

- 이메일 인증번호 불일치 메시지 개선
  - 인증번호 검증 결과가 실패일 때 `인증번호가 일치하지 않습니다.` 표시
  - 서버에서 `AUTH400_EMAIL_VERIFICATION` 에러가 내려오는 경우에도 동일한 메시지 표시
  - 6자리 미입력 등 클라이언트 validation 메시지는 기존대로 유지
  
 ## 반영 내용

- 이메일 인증번호 불일치 메시지 상수화
  - `ERROR_INVALID_EMAIL_CODE = "인증번호가 일치하지 않습니다."`
  - 인증 실패 응답/검증 실패 케이스에서 같은 상수 재사용

- 회원가입 페이지 레이아웃 중복 제거
  - 완료 화면과 기존 폼 화면이 동일한 `<section>` / 카드 컨테이너를 공유하도록 리팩토링
  - `isSubmitted` 상태에 따라 카드 내부 콘텐츠만 조건부 렌더링

## 📸 스크린샷

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/ee467100-3ce5-4529-8c8b-cea92d4cdb4c" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
