### PR TITLE
Feat(#63): ZIP파일 UI 상태 표시 추가

### DIFF
--- a/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
+++ b/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   Image,
   Paperclip,
+  Archive,
   Share2,
 } from "lucide-react";
 import type { ReactNode } from "react";
@@ -195,8 +196,9 @@ const AttachmentItem = ({
       ? toBackendAssetUrl(attachment.previewPdfPath)
       : "";
   const downloadUrl =
+    (attachment.localPath ? toBackendAssetUrl(attachment.localPath) : "") ||
     attachment.sourceUrl ||
-    (attachment.localPath ? toBackendAssetUrl(attachment.localPath) : "");
+    "";
   const hasPdfPreview = Boolean(previewUrl);
   const isDownloadable = Boolean(downloadUrl);
   const meta = [
@@ -206,12 +208,19 @@ const AttachmentItem = ({
     .filter(Boolean)
     .join(" · ");
   const isImage = isImageAttachment(attachment);
+  const isArchive = isArchiveAttachment(attachment);
   const statusLabel = getAttachmentStatusLabel(attachment);
 
   const content = (
     <>
       <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-600 group-hover:bg-white group-hover:text-[#2046FF]">
-        {isImage ? <Image size={18} /> : <FileText size={18} />}
+        {isImage ? (
+          <Image size={18} />
+        ) : isArchive ? (
+          <Archive size={18} />
+        ) : (
+          <FileText size={18} />
+        )}
       </span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-bold text-slate-900">
@@ -287,6 +296,8 @@ const IMAGE_EXTENSIONS = new Set([
   "svg",
 ]);
 
+const ARCHIVE_EXTENSIONS = new Set(["zip", "7z", "rar", "tar", "gz"]);
+
 const buildVisibleAttachments = (attachments: NoticeAttachmentData[]) =>
   attachments.flatMap((attachment) => {
     if (
@@ -344,6 +355,10 @@ const isImageAttachment = (attachment: NoticeAttachmentData) =>
   attachment.mimeType?.toLowerCase().startsWith("image/") ||
   IMAGE_EXTENSIONS.has(attachment.ext?.toLowerCase() ?? "");
 
+const isArchiveAttachment = (attachment: NoticeAttachmentData) =>
+  attachment.fileType?.toLowerCase() === "archive" ||
+  ARCHIVE_EXTENSIONS.has(attachment.ext?.toLowerCase() ?? "");
+
 const getAttachmentStatusLabel = (attachment: NoticeAttachmentData) => {
   if (attachment.isPreviewFile) return "PDF preview file";
   if (
@@ -353,6 +368,7 @@ const getAttachmentStatusLabel = (attachment: NoticeAttachmentData) => {
     return "PDF 미리보기 가능";
   }
   if (isImageAttachment(attachment)) return "이미지 파일";
+  if (isArchiveAttachment(attachment)) return "압축파일";
   if (attachment.parseOk === null) return "";
   return attachment.parseOk ? "본문 추출 완료" : "본문 추출 실패";
 };


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #63 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 예: 리뷰 작성 API 개발
- 예: Prisma 모델 수정

수정한 내용:

  - Desktop/CAMPOST/CamPost-frontend/src/features/noticeDetail/components/NoticeDetailSidebar.tsx:197
      - 기존: sourceUrl 우선
      - 변경: localPath의 백엔드 /files/...zip 우선
      - 원문 URL이 만료되거나 직접 접근이 막혀도, 파이프라인이 이미 받은 로컬 ZIP을 내려받게 됨.

  - ZIP/7Z/RAR/TAR/GZ는 "본문 추출 실패" 대신 "압축파일"로 표시.
  - 압축파일 아이콘도 Archive 아이콘으로 구분되게 변경

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.
<img width="590" height="329" alt="image" src="https://github.com/user-attachments/assets/6df351c9-a230-411c-84e5-f2c4e4c17516" />

다운로드 기능 확인 완료

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 압축 파일 첨부물이 별도의 아이콘으로 구분되어 표시됩니다.
  * 파일 다운로드 경로 선택 로직이 개선되었습니다.
  * 첨부 파일 상태 표시가 확대되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-frontend/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->