### PR TITLE
Fix(#75): 대시보드 배너 유효링크 연결 작업

### DIFF
--- a/src/features/dashboard/components/HeroBannerCarousel.tsx
+++ b/src/features/dashboard/components/HeroBannerCarousel.tsx
@@ -1,57 +1,160 @@
-import { useState, useEffect } from "react";
-import { Calendar } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Calendar, Eye } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { ROUTES } from "../../../app/router/paths";
+import { fetchNotices } from "../../../shared/api/notice";
+import {
+  DEFAULT_DEPARTMENT_ID,
+  getBackendDeptCodeByDepartmentId,
+} from "../../../shared/constants/departments";
+import { formatDate, getDDay } from "../../../shared/utils/date";
+import type { NoticeDto } from "../types/notice";
 
-// Mock banner data
-const BANNERS = [
-  {
-    id: "b1",
-    title: "2026학년도 1학기 국가장학금 2차 신청 안내",
-    description:
-      "재학생은 원칙적으로 1차 신청만 가능하나, 구제신청을 통해 2차 신청이 가능합니다.",
-    dDay: 2,
-    date: "2026. 04. 14 (화) 18:00 마감",
-    bgColor: "from-[#2046FF] via-[#4064FF] to-purple-600",
-    linkId: "u1",
-  },
-  {
-    id: "b2",
-    title: "[네이버클라우드] 2026년 상반기 신입 공채",
-    description:
-      "소프트웨어학과 재학생 대상 오프라인 직무 상담회 및 설명회를 진행합니다.",
-    dDay: 5,
-    date: "2026. 04. 12 (일) 23:59 마감",
-    bgColor: "from-emerald-500 via-teal-500 to-cyan-600",
-    linkId: "u2",
-  },
-  {
-    id: "b3",
-    title: "제 16회 소프트웨어학과 캡스톤 디자인 경진대회",
-    description:
-      "올해 최고의 프로젝트를 가리는 캡스톤 디자인 경진대회 참가자를 모집합니다.",
-    dDay: 10,
-    date: "2026. 04. 20 (월) 18:00 마감",
-    bgColor: "from-orange-500 via-rose-500 to-pink-600",
-    linkId: "n2",
-  },
+const BANNER_LIMIT = 3;
+const BACKGROUNDS = [
+  "from-[#2046FF] via-[#4064FF] to-slate-900",
+  "from-emerald-600 via-teal-600 to-slate-900",
+  "from-rose-600 via-orange-500 to-slate-900",
 ];
 
+interface BannerNotice {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  dateLabel: string;
+  dDay?: number;
+  views: number;
+  bgColor: string;
+  mode: "deadline" | "popular";
+}
+
+const toBannerNotice = (
+  notice: NoticeDto,
+  index: number,
+  mode: BannerNotice["mode"],
+): BannerNotice => {
+  const dDay = getDDay(notice.deadline);
+  const deadlineLabel = notice.deadline
+    ? `${formatDate(notice.deadline)} 마감`
+    : `${formatDate(notice.date)} 게시`;
+
+  return {
+    id: String(notice.id),
+    title: notice.title,
+    description:
+      notice.target ||
+      notice.applyMethod ||
+      notice.category ||
+      "공지 상세 내용을 확인해 주세요.",
+    category: notice.category || "미분류",
+    dateLabel: deadlineLabel,
+    dDay: dDay ?? undefined,
+    views: notice.views ?? 0,
+    bgColor: BACKGROUNDS[index % BACKGROUNDS.length],
+    mode,
+  };
+};
+
+const buildBannerNotices = (
+  deadlineNotices: NoticeDto[],
+  recentNotices: NoticeDto[],
+) => {
+  const selected = new Map<string, BannerNotice>();
+
+  deadlineNotices
+    .filter((notice) => getDDay(notice.deadline) !== null)
+    .slice(0, BANNER_LIMIT)
+    .forEach((notice) => {
+      selected.set(
+        notice.articleId,
+        toBannerNotice(notice, selected.size, "deadline"),
+      );
+    });
+
+  if (selected.size < BANNER_LIMIT) {
+    recentNotices
+      .slice()
+      .sort((a, b) => (b.views ?? 0) - (a.views ?? 0))
+      .forEach((notice) => {
+        if (selected.size >= BANNER_LIMIT) return;
+        if (selected.has(notice.articleId)) return;
+        selected.set(
+          notice.articleId,
+          toBannerNotice(notice, selected.size, "popular"),
+        );
+      });
+  }
+
+  return Array.from(selected.values());
+};
+
 export const HeroBannerCarousel = () => {
-  const { departmentId = "" } = useParams();
+  const { departmentId = DEFAULT_DEPARTMENT_ID } = useParams();
+  const backendDeptCode = getBackendDeptCodeByDepartmentId(departmentId);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
 
-  // Auto-scroll logic
+  const { data: deadlineNotices = [], isPending: isDeadlinePending } = useQuery(
+    {
+      queryKey: ["notices", "hero", "deadline", departmentId, backendDeptCode],
+      queryFn: () =>
+        fetchNotices({
+          deptCode: backendDeptCode,
+          sortBy: "deadline",
+          limit: BANNER_LIMIT,
+        }),
+    },
+  );
+
+  const { data: recentNotices = [], isPending: isRecentPending } = useQuery({
+    queryKey: [
+      "notices",
+      "hero",
+      "popular-fallback",
+      departmentId,
+      backendDeptCode,
+    ],
+    queryFn: () =>
+      fetchNotices({
+        deptCode: backendDeptCode,
+        sortBy: "recent",
+        limit: 40,
+      }),
+  });
+
+  const banners = useMemo(
+    () => buildBannerNotices(deadlineNotices, recentNotices),
+    [deadlineNotices, recentNotices],
+  );
+
   useEffect(() => {
-    if (isPaused) return;
+    if (isPaused || banners.length <= 1) return;
 
     const timer = setInterval(() => {
-      setCurrentIndex((prev) => (prev + 1) % BANNERS.length);
-    }, 4000); // Change banner every 4 seconds
+      setCurrentIndex((prev) => (prev + 1) % banners.length);
+    }, 4000);
 
     return () => clearInterval(timer);
-  }, [currentIndex, isPaused]);
+  }, [banners.length, isPaused]);
+
+  const isLoading = isDeadlinePending || isRecentPending;
+
+  if (isLoading && banners.length === 0) {
+    return (
+      <div className="relative mb-10 flex h-[240px] w-full items-end overflow-hidden rounded-2xl bg-slate-900 p-8 shadow-lg">
+        <div className="absolute inset-0 bg-gradient-to-br from-slate-800 via-slate-700 to-slate-950" />
+        <div className="relative z-10 h-20 w-full max-w-2xl animate-pulse rounded-lg bg-white/10" />
+      </div>
+    );
+  }
+
+  if (banners.length === 0) {
+    return null;
+  }
+
+  const activeIndex = currentIndex % banners.length;
 
   return (
     <div
@@ -61,49 +164,57 @@ export const HeroBannerCarousel = () => {
       onFocus={() => setIsPaused(true)}
       onBlur={() => setIsPaused(false)}
     >
-      {/* Banner Slides */}
-      {BANNERS.map((banner, index) => (
+      {banners.map((banner, index) => (
         <div
           key={banner.id}
           className={`absolute inset-0 flex flex-col justify-end p-8 transition-opacity duration-1000 ease-in-out ${
-            index === currentIndex
+            index === activeIndex
               ? "z-10 opacity-100"
               : "pointer-events-none z-0 opacity-0"
           }`}
         >
-          {/* Background Gradient */}
           <div
-            className={`absolute inset-0 -z-10 bg-gradient-to-br ${banner.bgColor} opacity-90`}
+            className={`absolute inset-0 -z-10 bg-gradient-to-br ${banner.bgColor} opacity-95`}
           />
-          <div className="absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-white/20 via-transparent to-transparent opacity-50" />
+          <div className="absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.22),transparent_45%,rgba(15,23,42,0.28))]" />
 
           <div className="flex flex-col items-start gap-3 text-white">
             <span className="flex items-center gap-1.5 rounded-full border border-white/10 bg-white/20 px-2.5 py-1 text-[10px] font-bold tracking-wider text-white backdrop-blur-md">
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-red-400"></span>
-              마감 임박 (D-{banner.dDay})
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-red-400" />
+              {banner.mode === "deadline" && banner.dDay !== undefined
+                ? `마감 임박 (D-${banner.dDay})`
+                : "조회수 높은 공지"}
             </span>
 
-            <h2 className="w-full max-w-2xl truncate text-2xl leading-tight font-bold tracking-tight drop-shadow-md sm:text-3xl">
+            <h2 className="w-full max-w-2xl truncate text-2xl leading-tight font-bold tracking-normal drop-shadow-md sm:text-3xl">
               {banner.title}
             </h2>
 
-            <div className="flex items-center gap-4 text-xs font-medium text-white/90">
-              <span className="hidden max-w-md truncate opacity-80 sm:inline-block">
+            <div className="flex w-full flex-wrap items-center gap-x-4 gap-y-2 text-xs font-medium text-white/90">
+              <span className="hidden max-w-md truncate opacity-85 sm:inline-block">
                 {banner.description}
               </span>
-              <div className="hidden h-3 w-[1px] bg-white/30 sm:block"></div>
+              <div className="hidden h-3 w-[1px] bg-white/30 sm:block" />
               <div className="flex items-center gap-1.5">
                 <Calendar
                   size={14}
                   className="text-white/70"
                 />
-                <span>{banner.date}</span>
+                <span>{banner.dateLabel}</span>
               </div>
+              {banner.mode === "popular" && (
+                <div className="flex items-center gap-1.5">
+                  <Eye
+                    size={14}
+                    className="text-white/70"
+                  />
+                  <span>{banner.views.toLocaleString()}회</span>
+                </div>
+              )}
             </div>
 
-            {/* Clickable overlay link for the whole card to make it easy to click */}
             <Link
-              to={ROUTES.noticeDetail(departmentId, banner.linkId)}
+              to={ROUTES.noticeDetail(departmentId, banner.id)}
               className="absolute inset-0 z-20"
               aria-label={`${banner.title} 상세보기`}
             />
@@ -111,21 +222,22 @@ export const HeroBannerCarousel = () => {
         </div>
       ))}
 
-      {/* Pagination Indicators */}
-      <div className="absolute right-8 bottom-6 z-30 flex gap-2">
-        {BANNERS.map((_, index) => (
-          <button
-            key={index}
-            onClick={() => setCurrentIndex(index)}
-            className={`h-2 rounded-full transition-all duration-300 ${
-              index === currentIndex
-                ? "w-6 bg-white"
-                : "w-2 bg-white/40 hover:bg-white/60"
-            }`}
-            aria-label={`Go to slide ${index + 1}`}
-          />
-        ))}
-      </div>
+      {banners.length > 1 && (
+        <div className="absolute right-8 bottom-6 z-30 flex gap-2">
+          {banners.map((banner, index) => (
+            <button
+              key={banner.id}
+              onClick={() => setCurrentIndex(index)}
+              className={`h-2 rounded-full transition-all duration-300 ${
+                index === activeIndex
+                  ? "w-6 bg-white"
+                  : "w-2 bg-white/40 hover:bg-white/60"
+              }`}
+              aria-label={`Go to slide ${index + 1}`}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #75 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 예: 리뷰 작성 API 개발
- 예: Prisma 모델 수정


- 학과 대시보드 상단 배너의 mock 공지 데이터를 제거했습니다.
  - 실제 공지 API를 호출해 배너에 표시할 공지를 구성하도록 변경했습니
  다.
  - 마감일이 가까운 공지를 우선 노출하고, 부족할 경우 조회수 높은 공지
  로 대체하도록 fallback 로직을 추가했습니다.
  - 배너 클릭 시 `u1`, `u2`, `n2` 같은 임의 ID가 아닌 실제 `notice.id`
  기반 상세 페이지로 이동하도록 수정했습니다.
  - 데이터 로딩 중 skeleton UI를 표시하고, 표시할 공지가 없을 경우 배너
  를 렌더링하지 않도록 처리했습니다.


## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 배너가 고정된 데이터에서 동적 공지 데이터 기반으로 변경
  * 마감 임박 공지를 우선 표시하고 부족분은 인기도 기준으로 채움

* **Refactor**
  * 배너 로딩 중 스켈레톤 표시 추가
  * 슬라이드 자동 전환 및 페이지네이션 로직 최적화
  * 배너 상단 레이블을 마감 상황 또는 인기도로 구분 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-frontend/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->