### PR TITLE
Feat(#79): 마이페이지 기능 연동 (북마크/기본 학과/최근 본 공지)

### DIFF
--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -6,6 +6,7 @@ import {
 import { RootLayout } from "../layouts/RootLayout";
 import { DepartmentLayout } from "../layouts/DepartmentLayout";
 import { BookmarksPage } from "../../pages/bookmarks/BookmarksPage";
+import { RecentNoticesPage } from "../../pages/recent/RecentNoticesPage";
 import { DepartmentDashboardPage } from "../../pages/dashboard/DepartmentDashboardPage";
 import { LoginPage } from "../../pages/login/LoginPage";
 import { MyPage } from "../../pages/mypage/MyPage";
@@ -16,7 +17,22 @@ import { SignupPage } from "../../pages/signup/SignupPage";
 import { PrivateRoute } from "./PrivateRoute";
 import { PublicRoute } from "./PublicRoute";
 import { RouteErrorPage } from "./RouteErrorPage";
-import { DEFAULT_PUBLIC_ENTRY_PATH, ROUTE_PATHS } from "./paths";
+import { DEFAULT_PUBLIC_ENTRY_PATH, ROUTE_PATHS, ROUTES } from "./paths";
+import { getPreferredDepartmentId } from "../../shared/hooks/usePreferredDepartment";
+
+// 홈("/") 진입 시 사용자가 설정한 기본 학과로 보내고, 없으면 기본값으로 보낸다.
+const HomeRedirect = () => {
+  const preferredDepartmentId = getPreferredDepartmentId();
+  const target = preferredDepartmentId
+    ? ROUTES.departmentDashboard(preferredDepartmentId)
+    : DEFAULT_PUBLIC_ENTRY_PATH;
+  return (
+    <Navigate
+      to={target}
+      replace
+    />
+  );
+};
 
 const router = createBrowserRouter([
   {
@@ -29,12 +45,7 @@ const router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: (
-              <Navigate
-                to={DEFAULT_PUBLIC_ENTRY_PATH}
-                replace
-              />
-            ),
+            element: <HomeRedirect />,
           },
           { path: ROUTE_PATHS.login, element: <LoginPage /> },
           { path: ROUTE_PATHS.signup, element: <SignupPage /> },
@@ -62,6 +73,7 @@ const router = createBrowserRouter([
           },
           { path: ROUTE_PATHS.mypage, element: <MyPage /> },
           { path: ROUTE_PATHS.bookmarks, element: <BookmarksPage /> },
+          { path: ROUTE_PATHS.recent, element: <RecentNoticesPage /> },
         ],
       },
       { path: ROUTE_PATHS.notFound, element: <NotFoundPage /> },

--- a/src/app/router/paths.ts
+++ b/src/app/router/paths.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
   signup: "/signup",
   mypage: "/mypage",
   bookmarks: "/bookmarks",
+  recent: "/recent",
   onboardingProfile: "/onboarding/profile",
   departmentDashboard: (departmentId: string) => `/departments/${departmentId}`,
   noticeDetail: (departmentId: string, noticeId: string) =>
@@ -18,6 +19,7 @@ export const ROUTE_PATHS = {
   signup: "/signup",
   mypage: "/mypage",
   bookmarks: "/bookmarks",
+  recent: "/recent",
   onboardingProfile: "/onboarding/profile",
   departmentDashboard: "/departments/:departmentId",
   noticeDetail: "/departments/:departmentId/notices/:noticeId",

--- a/src/features/dashboard/components/NewDepartmentNotices.tsx
+++ b/src/features/dashboard/components/NewDepartmentNotices.tsx
@@ -38,7 +38,7 @@ export const NewDepartmentNotices = () => {
       category: notice.category || "미분류",
       date: formatDate(notice.date),
       dDay: undefined,
-      isBookmarked: false,
+      isBookmarked: notice.isBookmarked ?? false,
       thumbnailUrl: notice.thumbnailPath ?? undefined,
     }));
 

--- a/src/features/dashboard/components/NoticeCard.tsx
+++ b/src/features/dashboard/components/NoticeCard.tsx
@@ -1,6 +1,11 @@
-import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router-dom";
 import { Bookmark, Clock } from "lucide-react";
 import { ROUTES } from "../../../app/router/paths";
+import { addBookmark, removeBookmark } from "../../../shared/api/bookmark";
+import { toApiClientError } from "../../../shared/api/client";
+import { useAuth } from "../../../shared/hooks/useAuth";
 import { toBackendAssetUrl } from "../../../shared/utils/assets";
 import type { NoticeCardData } from "../types/notice";
 import {
@@ -16,9 +21,40 @@ interface NoticeCardProps {
 }
 
 export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+  const [isBookmarked, setIsBookmarked] = useState(
+    Boolean(notice.isBookmarked),
+  );
   const showDeadlineBadge = isDeadlineSoon(notice) || isDeadlinePassed(notice);
   const deadlineBadgeLabel = getDeadlineBadgeLabel(notice);
   const thumbnailUrl = toBackendAssetUrl(notice.thumbnailUrl);
+
+  const bookmarkMutation = useMutation({
+    mutationFn: (next: boolean) =>
+      next ? addBookmark(Number(notice.id)) : removeBookmark(Number(notice.id)),
+    onSuccess: (status) => setIsBookmarked(status.bookmarked),
+    onError: (error, next) => {
+      setIsBookmarked(!next); // 낙관적 토글 되돌리기
+      const apiError = toApiClientError(error);
+      if (apiError.status === 401) {
+        navigate(ROUTES.login);
+      }
+    },
+  });
+
+  const handleBookmarkClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!isAuthenticated) {
+      navigate(ROUTES.login);
+      return;
+    }
+    if (bookmarkMutation.isPending) return;
+    const next = !isBookmarked;
+    setIsBookmarked(next); // 낙관적 업데이트
+    bookmarkMutation.mutate(next);
+  };
 
   return (
     <div className="group relative flex h-[300px] w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white transition-all hover:-translate-y-1 hover:border-[#2046FF]/30 hover:shadow-lg hover:shadow-[#2046FF]/10">
@@ -89,18 +125,14 @@ export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
       {/* Bookmark Button as a sibling to Link to avoid nested interactive elements */}
       <button
         className="absolute right-5 bottom-5 z-10 text-slate-300 transition-colors hover:text-[#2046FF]"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          // Bookmark logic will go here
-        }}
+        onClick={handleBookmarkClick}
         aria-label="북마크"
-        aria-pressed={notice.isBookmarked}
+        aria-pressed={isBookmarked}
       >
         <Bookmark
           size={16}
-          fill={notice.isBookmarked ? "currentColor" : "none"}
-          className={notice.isBookmarked ? "text-[#2046FF]" : ""}
+          fill={isBookmarked ? "currentColor" : "none"}
+          className={isBookmarked ? "text-[#2046FF]" : ""}
         />
       </button>
     </div>

--- a/src/features/dashboard/components/TrendingNotices.tsx
+++ b/src/features/dashboard/components/TrendingNotices.tsx
@@ -34,7 +34,7 @@ export const TrendingNotices = () => {
     category: notice.category || "미분류",
     date: formatDate(notice.date),
     dDay: undefined,
-    isBookmarked: false,
+    isBookmarked: notice.isBookmarked ?? false,
     thumbnailUrl: notice.thumbnailPath ?? undefined,
   }));
 

--- a/src/features/dashboard/components/UrgentNotices.tsx
+++ b/src/features/dashboard/components/UrgentNotices.tsx
@@ -34,7 +34,7 @@ export const UrgentNotices = () => {
     category: notice.category || "미분류",
     date: formatDate(notice.date),
     dDay: getDDay(notice.deadline) ?? undefined,
-    isBookmarked: false,
+    isBookmarked: notice.isBookmarked ?? false,
     thumbnailUrl: notice.thumbnailPath ?? undefined,
   }));
 

--- a/src/features/dashboard/types/notice.ts
+++ b/src/features/dashboard/types/notice.ts
@@ -16,6 +16,7 @@ export interface NoticeDto {
   applyMethod: string | null;
   publishedAt: string | null;
   createdAt: string | null;
+  isBookmarked: boolean | null;
 }
 
 export interface NoticeCardData {

--- a/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
+++ b/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import {
   Bookmark,
   Calendar,
@@ -13,6 +15,10 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { toBackendAssetUrl } from "../../../shared/utils/assets";
+import { addBookmark, removeBookmark } from "../../../shared/api/bookmark";
+import { toApiClientError } from "../../../shared/api/client";
+import { useAuth } from "../../../shared/hooks/useAuth";
+import { ROUTES } from "../../../app/router/paths";
 import type { NoticeAttachmentData, NoticeDetailData } from "../types";
 
 interface NoticeDetailSidebarProps {
@@ -20,6 +26,8 @@ interface NoticeDetailSidebarProps {
 }
 
 export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
   const [bookmarkState, setBookmarkState] = useState({
     noticeId: notice.id,
     isBookmarked: notice.isBookmarked,
@@ -30,11 +38,39 @@ export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
       ? bookmarkState.isBookmarked
       : notice.isBookmarked;
 
+  const bookmarkMutation = useMutation({
+    mutationFn: (next: boolean) =>
+      next ? addBookmark(Number(notice.id)) : removeBookmark(Number(notice.id)),
+    onSuccess: (status) => {
+      setBookmarkState({
+        noticeId: notice.id,
+        isBookmarked: status.bookmarked,
+      });
+    },
+    onError: (error, next) => {
+      // 실패 시 낙관적 토글 되돌리기
+      setBookmarkState({ noticeId: notice.id, isBookmarked: !next });
+      const apiError = toApiClientError(error);
+      if (apiError.status === 401) {
+        navigate(ROUTES.login);
+        return;
+      }
+      window.alert(apiError.message);
+    },
+  });
+
   const handleBookmarkToggle = () => {
-    setBookmarkState({
-      noticeId: notice.id,
-      isBookmarked: !isBookmarked,
-    });
+    if (!isAuthenticated) {
+      navigate(ROUTES.login);
+      return;
+    }
+    if (bookmarkMutation.isPending) {
+      return;
+    }
+    const next = !isBookmarked;
+    // 낙관적 업데이트: 응답 전 UI 먼저 토글
+    setBookmarkState({ noticeId: notice.id, isBookmarked: next });
+    bookmarkMutation.mutate(next);
   };
 
   return (

--- a/src/features/noticeDetail/types.ts
+++ b/src/features/noticeDetail/types.ts
@@ -83,6 +83,7 @@ export interface NoticeDetailDto {
   sourceUrl: string | null;
   publishedAt: string | null;
   createdAt: string | null;
+  isBookmarked: boolean | null;
 }
 
 export interface NoticeAttachmentDto {

--- a/src/pages/dashboard/DepartmentDashboardPage.tsx
+++ b/src/pages/dashboard/DepartmentDashboardPage.tsx
@@ -62,7 +62,7 @@ export const DepartmentDashboardPage = () => {
         category: notice.category || "미분류",
         date: formatDate(notice.date),
         dDay: getDDay(notice.deadline) ?? undefined,
-        isBookmarked: false,
+        isBookmarked: notice.isBookmarked ?? false,
         thumbnailUrl: notice.thumbnailPath ?? undefined,
         summary: notice.target || undefined,
         hasAttachment: false,

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -42,6 +42,7 @@ import {
 } from "../../shared/hooks/useOnboardingProfileDraft";
 import {
   clearPreferredDepartmentId,
+  getPreferredDepartmentId,
   setPreferredDepartmentId,
 } from "../../shared/hooks/usePreferredDepartment";
 
@@ -178,6 +179,10 @@ export const MyPage = () => {
   const [accountDeleteErrorMessage, setAccountDeleteErrorMessage] =
     useState("");
   const [isSavingAccountDelete, setIsSavingAccountDelete] = useState(false);
+  const [isEditingDefaultDept, setIsEditingDefaultDept] = useState(false);
+  const [defaultDeptId, setDefaultDeptId] = useState(
+    () => getPreferredDepartmentId() ?? "",
+  );
 
   useEffect(() => {
     let isMounted = true;
@@ -257,6 +262,7 @@ export const MyPage = () => {
   const openProfileEditForm = () => {
     setIsChangingPassword(false);
     setIsDeletingAccount(false);
+    setIsEditingDefaultDept(false);
     setEditForm({
       department: departmentCode || "",
       grade: grade || "",
@@ -270,6 +276,7 @@ export const MyPage = () => {
   const openPasswordChangeForm = () => {
     setIsEditingProfile(false);
     setIsDeletingAccount(false);
+    setIsEditingDefaultDept(false);
     setEditSuccessMessage("");
     setPasswordForm(initialPasswordChangeForm);
     setPasswordErrorMessage("");
@@ -280,11 +287,25 @@ export const MyPage = () => {
   const openAccountDeleteForm = () => {
     setIsEditingProfile(false);
     setIsChangingPassword(false);
+    setIsEditingDefaultDept(false);
     setEditSuccessMessage("");
     setPasswordSuccessMessage("");
     setAccountDeleteForm(initialAccountDeleteForm);
     setAccountDeleteErrorMessage("");
     setIsDeletingAccount(true);
+  };
+
+  const openDefaultDeptForm = () => {
+    setIsEditingProfile(false);
+    setIsChangingPassword(false);
+    setIsDeletingAccount(false);
+    setDefaultDeptId(getPreferredDepartmentId() ?? "");
+    setIsEditingDefaultDept(true);
+  };
+
+  const handleSelectDefaultDept = (departmentId: string) => {
+    setPreferredDepartmentId(departmentId);
+    setDefaultDeptId(departmentId);
   };
 
   const closeProfileEditForm = () => {
@@ -837,6 +858,66 @@ export const MyPage = () => {
           </section>
         )}
 
+        {isEditingDefaultDept && (
+          <section className="mt-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] sm:p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-bold text-slate-950">
+                  기본 학과 설정
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  앱에 처음 들어왔을 때 보여줄 공지 학과를 선택합니다. 선택 즉시
+                  저장됩니다.
+                </p>
+              </div>
+
+              <button
+                aria-label="기본 학과 설정 닫기"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
+                onClick={() => setIsEditingDefaultDept(false)}
+                type="button"
+              >
+                <X
+                  aria-hidden="true"
+                  className="h-4 w-4"
+                />
+              </button>
+            </div>
+
+            <div className="mt-5 grid gap-2 sm:grid-cols-2">
+              {DEPARTMENTS.map((department) => {
+                const isSelected = department.id === defaultDeptId;
+
+                return (
+                  <button
+                    className={`flex h-12 items-center justify-between rounded-xl border px-4 text-left text-sm font-bold transition ${
+                      isSelected
+                        ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
+                        : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                    }`}
+                    key={department.id}
+                    onClick={() => handleSelectDefaultDept(department.id)}
+                    type="button"
+                  >
+                    {department.name}
+                    {isSelected && (
+                      <span className="h-2 w-2 rounded-full bg-[#2046FF]" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-4 rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-500">
+              현재 기본 학과:{" "}
+              <span className="font-bold text-slate-800">
+                {DEPARTMENTS.find((dept) => dept.id === defaultDeptId)?.name ??
+                  "기본값 (소프트웨어학과)"}
+              </span>
+            </div>
+          </section>
+        )}
+
         <div className="mt-5 space-y-4">
           <MenuSection
             items={[
@@ -874,13 +955,13 @@ export const MyPage = () => {
                 title: "최근 본 공지",
                 description: "다시 확인할 공지",
                 icon: <Clock3 className="h-5 w-5" />,
-                badge: "준비 중",
+                to: ROUTES.recent,
               },
               {
                 title: "기본 학과 설정",
                 description: "처음 보여줄 공지 학과",
                 icon: <GraduationCap className="h-5 w-5" />,
-                badge: "준비 중",
+                onClick: openDefaultDeptForm,
               },
             ]}
             title="공지"

--- a/src/pages/noticeDetail/NoticeDetailPage.tsx
+++ b/src/pages/noticeDetail/NoticeDetailPage.tsx
@@ -69,6 +69,8 @@ export const NoticeDetailPage = () => {
   });
 
   // 공지 상세 진입 시 "최근 본 공지"에 기록한다 (localStorage 기반).
+  // 같은 공지(id)에 대해 1회만 기록하면 되므로 id만 의존성으로 사용한다.
+  // (noticeDetail 객체 전체를 의존하면 리페치마다 불필요하게 재실행됨)
   useEffect(() => {
     if (!noticeDetail) return;
     addRecentlyViewedNotice({
@@ -80,7 +82,8 @@ export const NoticeDetailPage = () => {
       thumbnailPath: null,
       department: noticeDetail.department,
     });
-  }, [noticeDetail]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [noticeDetail?.id]);
 
   if (!hasValidNoticeId) {
     return (

--- a/src/pages/noticeDetail/NoticeDetailPage.tsx
+++ b/src/pages/noticeDetail/NoticeDetailPage.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronRight } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { ROUTES } from "../../app/router/paths";
+import { addRecentlyViewedNotice } from "../../shared/hooks/useRecentlyViewedNotices";
 import { NoticeDetailContent } from "../../features/noticeDetail/components/NoticeDetailContent";
 import { NoticeDetailRecommendations } from "../../features/noticeDetail/components/NoticeDetailRecommendations";
 import { NoticeDetailSidebar } from "../../features/noticeDetail/components/NoticeDetailSidebar";
@@ -61,10 +63,24 @@ export const NoticeDetailPage = () => {
           category: notice.category || "미분류",
           date: formatDate(notice.date),
           dDay: undefined,
-          isBookmarked: false,
+          isBookmarked: notice.isBookmarked ?? false,
           thumbnailUrl: notice.thumbnailPath ?? undefined,
         })),
   });
+
+  // 공지 상세 진입 시 "최근 본 공지"에 기록한다 (localStorage 기반).
+  useEffect(() => {
+    if (!noticeDetail) return;
+    addRecentlyViewedNotice({
+      id: String(noticeDetail.id),
+      title: noticeDetail.title,
+      category: noticeDetail.category,
+      date: noticeDetail.date,
+      deadline: noticeDetail.deadline,
+      thumbnailPath: null,
+      department: noticeDetail.department,
+    });
+  }, [noticeDetail]);
 
   if (!hasValidNoticeId) {
     return (
@@ -186,7 +202,7 @@ const toNoticeDetailData = (notice: NoticeDetailDto): NoticeDetailData => {
     target: notice.target || "제한 없음",
     applyMethod: notice.applyMethod || "별도 안내 없음",
     views: notice.views ?? 0,
-    isBookmarked: false,
+    isBookmarked: notice.isBookmarked ?? false,
     bodyText: notice.bodyText || "",
     bodyHtml: notice.bodyHtml || "",
     contentHtml: notice.contentHtml || "",

--- a/src/pages/recent/RecentNoticesPage.tsx
+++ b/src/pages/recent/RecentNoticesPage.tsx
@@ -1,70 +1,52 @@
-import { useQuery } from "@tanstack/react-query";
-import { Bookmark } from "lucide-react";
+import { Clock3 } from "lucide-react";
 import { NoticeCard } from "../../features/dashboard/components/NoticeCard";
 import type { NoticeCardData } from "../../features/dashboard/types/notice";
-import { fetchBookmarkedNotices } from "../../shared/api/bookmark";
 import { getDepartmentIdByName } from "../../shared/constants/departments";
-import { useAuth } from "../../shared/hooks/useAuth";
+import { useRecentlyViewedNotices } from "../../shared/hooks/useRecentlyViewedNotices";
 import { formatDate, getDDay } from "../../shared/utils/date";
 
-export const BookmarksPage = () => {
-  const { isAuthenticated } = useAuth();
-
-  const {
-    data: notices = [],
-    isPending,
-    isError,
-  } = useQuery({
-    queryKey: ["bookmarked-notices"],
-    queryFn: () => fetchBookmarkedNotices(),
-    enabled: isAuthenticated,
-  });
+export const RecentNoticesPage = () => {
+  const recentNotices = useRecentlyViewedNotices();
 
   return (
     <main className="w-full pb-20">
       <div className="mb-8 flex items-center gap-3">
         <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#2046FF]/10 text-[#2046FF]">
-          <Bookmark size={22} />
+          <Clock3 size={22} />
         </span>
         <div>
           <h1 className="text-2xl font-extrabold tracking-tight text-slate-900">
-            북마크한 공지
+            최근 본 공지
           </h1>
           <p className="mt-0.5 text-sm text-slate-500">
-            저장한 공지를 모아봅니다.
+            최근에 확인한 공지를 모아봅니다.
           </p>
         </div>
       </div>
 
-      {isPending ? (
-        <p className="text-sm text-slate-500">불러오는 중입니다...</p>
-      ) : isError ? (
-        <p className="text-sm text-rose-600">
-          북마크 목록을 불러오지 못했습니다.
-        </p>
-      ) : notices.length === 0 ? (
+      {recentNotices.length === 0 ? (
         <section className="rounded-2xl border border-slate-200 bg-slate-50 p-12 text-center">
-          <Bookmark
+          <Clock3
             size={32}
             className="mx-auto mb-3 text-slate-300"
           />
           <p className="font-semibold text-slate-700">
-            아직 북마크한 공지가 없습니다.
+            아직 본 공지가 없습니다.
           </p>
           <p className="mt-1 text-sm text-slate-500">
-            공지 상세 페이지에서 북마크를 눌러 저장해 보세요.
+            공지를 열람하면 여기에 최근 본 순서로 쌓입니다.
           </p>
         </section>
       ) : (
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {notices.map((notice) => {
+          {recentNotices.map((notice) => {
             const cardData: NoticeCardData = {
-              id: String(notice.id),
+              id: notice.id,
               title: notice.title,
               category: notice.category || "미분류",
               date: formatDate(notice.date),
               dDay: getDDay(notice.deadline) ?? undefined,
-              isBookmarked: true,
+              isBookmarked: false,
               thumbnailUrl: notice.thumbnailPath ?? undefined,
             };
             return (

--- a/src/shared/api/bookmark.ts
+++ b/src/shared/api/bookmark.ts
@@ -1,0 +1,36 @@
+import { apiClient, unwrapResponse } from "./client";
+import type { ApiResponse } from "../types/api";
+import type { NoticeDto } from "../../features/dashboard/types/notice";
+
+export interface BookmarkStatus {
+  noticeId: number;
+  bookmarked: boolean;
+}
+
+export const fetchBookmarkedNotices = async (
+  limit = 50,
+): Promise<NoticeDto[]> => {
+  const response = await apiClient.get<ApiResponse<NoticeDto[]>>(
+    "/api/v1/notices/bookmarked",
+    { params: { limit } },
+  );
+  return unwrapResponse(response.data);
+};
+
+export const addBookmark = async (
+  noticeId: number,
+): Promise<BookmarkStatus> => {
+  const response = await apiClient.post<ApiResponse<BookmarkStatus>>(
+    `/api/v1/notices/${noticeId}/bookmark`,
+  );
+  return unwrapResponse(response.data);
+};
+
+export const removeBookmark = async (
+  noticeId: number,
+): Promise<BookmarkStatus> => {
+  const response = await apiClient.delete<ApiResponse<BookmarkStatus>>(
+    `/api/v1/notices/${noticeId}/bookmark`,
+  );
+  return unwrapResponse(response.data);
+};

--- a/src/shared/api/notice.ts
+++ b/src/shared/api/notice.ts
@@ -1,5 +1,4 @@
-import axios from "axios";
-import { API_BASE_URL } from "../config/env";
+import { apiClient } from "./client";
 import type { ApiResponse } from "../types/api";
 import type {
   NoticeDto,
@@ -7,11 +6,8 @@ import type {
 } from "../../features/dashboard/types/notice";
 import type { NoticeDetailDto } from "../../features/noticeDetail/types";
 
-const noticeApiClient = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 10000,
-});
-
+// 공지 조회는 공개 엔드포인트지만, 로그인 상태면 JWT를 함께 보내 isBookmarked를
+// 채워 받기 위해 토큰을 자동 첨부하는 apiClient를 사용한다. (선택적 인증)
 interface FetchNoticesParams {
   deptCode?: string;
   sortBy?: NoticeSortBy;
@@ -23,7 +19,7 @@ export const fetchNotices = async ({
   sortBy = "recent",
   limit = 4,
 }: FetchNoticesParams): Promise<NoticeDto[]> => {
-  const response = await noticeApiClient.get<ApiResponse<NoticeDto[]>>(
+  const response = await apiClient.get<ApiResponse<NoticeDto[]>>(
     "/api/v1/notices",
     {
       params: {
@@ -44,7 +40,7 @@ export const fetchNotices = async ({
 export const fetchNoticeDetail = async (
   noticeId: number,
 ): Promise<NoticeDetailDto> => {
-  const response = await noticeApiClient.get<ApiResponse<NoticeDetailDto>>(
+  const response = await apiClient.get<ApiResponse<NoticeDetailDto>>(
     `/api/v1/notices/${noticeId}`,
   );
 

--- a/src/shared/constants/departments.ts
+++ b/src/shared/constants/departments.ts
@@ -27,3 +27,9 @@ export const getBackendDeptCodeByDepartmentId = (departmentId: string) => {
   const department = getDepartmentById(departmentId);
   return department?.backendDeptCode || DEFAULT_BACKEND_DEPT_CODE;
 };
+
+export const getDepartmentIdByName = (name: string | null | undefined) => {
+  if (!name) return DEFAULT_DEPARTMENT_ID;
+  const department = DEPARTMENTS.find((dept) => dept.name === name.trim());
+  return department?.id || DEFAULT_DEPARTMENT_ID;
+};

--- a/src/shared/hooks/useRecentlyViewedNotices.ts
+++ b/src/shared/hooks/useRecentlyViewedNotices.ts
@@ -35,11 +35,19 @@ export const addRecentlyViewedNotice = (
     0,
     MAX_RECENT,
   );
-  localStorage.setItem(RECENTLY_VIEWED_KEY, JSON.stringify(next));
+  try {
+    localStorage.setItem(RECENTLY_VIEWED_KEY, JSON.stringify(next));
+  } catch {
+    // 시크릿 모드·저장공간 부족·쿠키 차단 등으로 쓰기 실패 시 무시 (최근 본 공지는 부가 기능)
+  }
 };
 
 export const clearRecentlyViewedNotices = () => {
-  localStorage.removeItem(RECENTLY_VIEWED_KEY);
+  try {
+    localStorage.removeItem(RECENTLY_VIEWED_KEY);
+  } catch {
+    // 저장소 접근 불가 시 무시
+  }
 };
 
 // 마운트 시점의 스냅샷을 반환한다. (페이지 진입 시 1회 로드)

--- a/src/shared/hooks/useRecentlyViewedNotices.ts
+++ b/src/shared/hooks/useRecentlyViewedNotices.ts
@@ -1,0 +1,49 @@
+import { useState } from "react";
+
+const RECENTLY_VIEWED_KEY = "campost.recently-viewed-notices";
+const MAX_RECENT = 20;
+
+export interface RecentNotice {
+  id: string;
+  title: string;
+  category: string | null;
+  date: string | null;
+  deadline: string | null;
+  thumbnailPath: string | null;
+  department: string | null;
+  viewedAt: number;
+}
+
+const read = (): RecentNotice[] => {
+  try {
+    const raw = localStorage.getItem(RECENTLY_VIEWED_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as RecentNotice[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const getRecentlyViewedNotices = (): RecentNotice[] => read();
+
+export const addRecentlyViewedNotice = (
+  notice: Omit<RecentNotice, "viewedAt">,
+) => {
+  const current = read().filter((item) => item.id !== notice.id);
+  const next = [{ ...notice, viewedAt: Date.now() }, ...current].slice(
+    0,
+    MAX_RECENT,
+  );
+  localStorage.setItem(RECENTLY_VIEWED_KEY, JSON.stringify(next));
+};
+
+export const clearRecentlyViewedNotices = () => {
+  localStorage.removeItem(RECENTLY_VIEWED_KEY);
+};
+
+// 마운트 시점의 스냅샷을 반환한다. (페이지 진입 시 1회 로드)
+export const useRecentlyViewedNotices = () => {
+  const [recentNotices] = useState<RecentNotice[]>(() => read());
+  return recentNotices;
+};


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #79

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- **북마크 토글** 연결 (공지 상세 + 홈/대시보드 카드) — 미로그인 시 로그인 이동, 낙관적 업데이트
- **북마크한 공지 목록** 페이지 구현 (`GET /notices/bookmarked` 연동)
- 공지 목록/상세에서 **isBookmarked 반영** — `apiClient`로 JWT 첨부하도록 전환
- **기본 학과 설정** — 홈("/") 진입이 preferred 학과 반영 + 마이페이지 인라인 학과 선택
- **최근 본 공지** — localStorage 기반 기록 + 전용 페이지

## 📎 기타 참고사항

- 백엔드 PR(Team-CamPost/CamPost-backend#88)과 함께 배포되어야 북마크 목록/상태가 동작
- 로컬 검증: tsc / eslint / prettier / build 전부 통과
- 최근 본 공지는 기기별 localStorage 기반 (서버 동기화 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 최근 본 공지 페이지 추가 - 사용자가 최근에 본 공지들을 한눈에 확인
  * 북마크 기능 확장 - 공지 북마크/해제 및 북마크된 공지 전용 페이지 추가
  * 기본 학과 설정 기능 - 마이페이지에서 선호하는 학과를 설정하면 홈 진입 시 해당 학과 대시보드로 이동

* **개선 사항**
  * 북마크 상태가 서버와 실시간으로 동기화
  * 사용자 인증 상태에 따른 더 나은 접근 제어

<!-- end of auto-generated comment: release notes by coderabbit.ai -->