### PR TITLE
Style(#81): 북마크/최근 본 공지 페이지 카드 그리드 UI 통일

### DIFF
--- a/src/pages/bookmarks/BookmarksPage.tsx
+++ b/src/pages/bookmarks/BookmarksPage.tsx
@@ -21,62 +21,64 @@ export const BookmarksPage = () => {
   });
 
   return (
-    <main className="w-full pb-20">
-      <div className="mb-8 flex items-center gap-3">
-        <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#2046FF]/10 text-[#2046FF]">
-          <Bookmark size={22} />
-        </span>
-        <div>
-          <h1 className="text-2xl font-extrabold tracking-tight text-slate-900">
-            북마크한 공지
-          </h1>
-          <p className="mt-0.5 text-sm text-slate-500">
-            저장한 공지를 모아봅니다.
-          </p>
+    <main className="w-full">
+      <div className="mx-auto w-full max-w-[1600px] px-6 py-8 lg:px-12">
+        <div className="mb-8 flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#2046FF]/10 text-[#2046FF]">
+            <Bookmark size={22} />
+          </span>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900">
+              북마크한 공지
+            </h1>
+            <p className="mt-1 text-sm text-slate-500">
+              저장한 공지를 모아봅니다.
+            </p>
+          </div>
         </div>
-      </div>
 
-      {isPending ? (
-        <p className="text-sm text-slate-500">불러오는 중입니다...</p>
-      ) : isError ? (
-        <p className="text-sm text-rose-600">
-          북마크 목록을 불러오지 못했습니다.
-        </p>
-      ) : notices.length === 0 ? (
-        <section className="rounded-2xl border border-slate-200 bg-slate-50 p-12 text-center">
-          <Bookmark
-            size={32}
-            className="mx-auto mb-3 text-slate-300"
-          />
-          <p className="font-semibold text-slate-700">
-            아직 북마크한 공지가 없습니다.
+        {isPending ? (
+          <p className="text-sm text-slate-500">불러오는 중입니다...</p>
+        ) : isError ? (
+          <p className="text-sm text-rose-600">
+            북마크 목록을 불러오지 못했습니다.
           </p>
-          <p className="mt-1 text-sm text-slate-500">
-            공지 상세 페이지에서 북마크를 눌러 저장해 보세요.
-          </p>
-        </section>
-      ) : (
-        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {notices.map((notice) => {
-            const cardData: NoticeCardData = {
-              id: String(notice.id),
-              title: notice.title,
-              category: notice.category || "미분류",
-              date: formatDate(notice.date),
-              dDay: getDDay(notice.deadline) ?? undefined,
-              isBookmarked: true,
-              thumbnailUrl: notice.thumbnailPath ?? undefined,
-            };
-            return (
-              <NoticeCard
-                key={notice.id}
-                notice={cardData}
-                departmentId={getDepartmentIdByName(notice.department)}
-              />
-            );
-          })}
-        </div>
-      )}
+        ) : notices.length === 0 ? (
+          <div className="rounded-2xl border border-slate-200 bg-white px-6 py-12 text-center">
+            <Bookmark
+              size={32}
+              className="mx-auto mb-3 text-slate-300"
+            />
+            <p className="font-semibold text-slate-700">
+              아직 북마크한 공지가 없습니다.
+            </p>
+            <p className="mt-1 text-sm text-slate-500">
+              공지 상세 페이지에서 북마크를 눌러 저장해 보세요.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {notices.map((notice) => {
+              const cardData: NoticeCardData = {
+                id: String(notice.id),
+                title: notice.title,
+                category: notice.category || "미분류",
+                date: formatDate(notice.date),
+                dDay: getDDay(notice.deadline) ?? undefined,
+                isBookmarked: true,
+                thumbnailUrl: notice.thumbnailPath ?? undefined,
+              };
+              return (
+                <NoticeCard
+                  key={notice.id}
+                  notice={cardData}
+                  departmentId={getDepartmentIdByName(notice.department)}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
     </main>
   );
 };

--- a/src/pages/recent/RecentNoticesPage.tsx
+++ b/src/pages/recent/RecentNoticesPage.tsx
@@ -9,56 +9,58 @@ export const RecentNoticesPage = () => {
   const recentNotices = useRecentlyViewedNotices();
 
   return (
-    <main className="w-full pb-20">
-      <div className="mb-8 flex items-center gap-3">
-        <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#2046FF]/10 text-[#2046FF]">
-          <Clock3 size={22} />
-        </span>
-        <div>
-          <h1 className="text-2xl font-extrabold tracking-tight text-slate-900">
-            최근 본 공지
-          </h1>
-          <p className="mt-0.5 text-sm text-slate-500">
-            최근에 확인한 공지를 모아봅니다.
-          </p>
+    <main className="w-full">
+      <div className="mx-auto w-full max-w-[1600px] px-6 py-8 lg:px-12">
+        <div className="mb-8 flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#2046FF]/10 text-[#2046FF]">
+            <Clock3 size={22} />
+          </span>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900">
+              최근 본 공지
+            </h1>
+            <p className="mt-1 text-sm text-slate-500">
+              최근에 확인한 공지를 모아봅니다.
+            </p>
+          </div>
         </div>
-      </div>
 
-      {recentNotices.length === 0 ? (
-        <section className="rounded-2xl border border-slate-200 bg-slate-50 p-12 text-center">
-          <Clock3
-            size={32}
-            className="mx-auto mb-3 text-slate-300"
-          />
-          <p className="font-semibold text-slate-700">
-            아직 본 공지가 없습니다.
-          </p>
-          <p className="mt-1 text-sm text-slate-500">
-            공지를 열람하면 여기에 최근 본 순서로 쌓입니다.
-          </p>
-        </section>
-      ) : (
-        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {recentNotices.map((notice) => {
-            const cardData: NoticeCardData = {
-              id: notice.id,
-              title: notice.title,
-              category: notice.category || "미분류",
-              date: formatDate(notice.date),
-              dDay: getDDay(notice.deadline) ?? undefined,
-              isBookmarked: false,
-              thumbnailUrl: notice.thumbnailPath ?? undefined,
-            };
-            return (
-              <NoticeCard
-                key={notice.id}
-                notice={cardData}
-                departmentId={getDepartmentIdByName(notice.department)}
-              />
-            );
-          })}
-        </div>
-      )}
+        {recentNotices.length === 0 ? (
+          <div className="rounded-2xl border border-slate-200 bg-white px-6 py-12 text-center">
+            <Clock3
+              size={32}
+              className="mx-auto mb-3 text-slate-300"
+            />
+            <p className="font-semibold text-slate-700">
+              아직 본 공지가 없습니다.
+            </p>
+            <p className="mt-1 text-sm text-slate-500">
+              공지를 열람하면 여기에 최근 본 순서로 쌓입니다.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {recentNotices.map((notice) => {
+              const cardData: NoticeCardData = {
+                id: notice.id,
+                title: notice.title,
+                category: notice.category || "미분류",
+                date: formatDate(notice.date),
+                dDay: getDDay(notice.deadline) ?? undefined,
+                isBookmarked: false,
+                thumbnailUrl: notice.thumbnailPath ?? undefined,
+              };
+              return (
+                <NoticeCard
+                  key={notice.id}
+                  notice={cardData}
+                  departmentId={getDepartmentIdByName(notice.department)}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
     </main>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #81

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 북마크/최근 본 공지 페이지를 대시보드와 동일한 컨테이너(`max-w-[1600px]`, `px-6 lg:px-12`) + `xl:grid-cols-4` 그리드로 통일
- 풀블리드로 과도하게 크던 카드를 대시보드 카드 크기와 동일하게 정렬
- 빈 상태 UI 톤 정리

## 📎 기타 참고사항

- #79(마이페이지 기능 연동, 머지됨) 후속 UI 정리
- 마이페이지 영역은 사이드바 없이 카드 크기만 대시보드와 일치
- 로컬 검증: tsc / eslint / prettier / build 통과