### PR TITLE
Fix/Feat(#83): 북마크 즉시 반영 + 로그인 필요 모달 + 마이페이지 설정 모달화

### DIFF
--- a/src/app/layouts/RootLayout.tsx
+++ b/src/app/layouts/RootLayout.tsx
@@ -2,18 +2,21 @@ import { Outlet, useLocation } from "react-router-dom";
 import { Header } from "./components/Header";
 import { ScrollToTop } from "../router/ScrollToTop";
 import { ROUTE_PATHS } from "../router/paths";
+import { LoginRequiredProvider } from "../../shared/components/LoginRequiredModal";
 
 export const RootLayout = () => {
   const location = useLocation();
   const shouldHideHeader = location.pathname === ROUTE_PATHS.onboardingProfile;
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-50/30 font-sans text-slate-900">
-      <ScrollToTop />
-      {!shouldHideHeader && <Header />}
-      <main className="relative flex w-full flex-1 flex-col">
-        <Outlet />
-      </main>
-    </div>
+    <LoginRequiredProvider>
+      <div className="flex min-h-screen flex-col bg-slate-50/30 font-sans text-slate-900">
+        <ScrollToTop />
+        {!shouldHideHeader && <Header />}
+        <main className="relative flex w-full flex-1 flex-col">
+          <Outlet />
+        </main>
+      </div>
+    </LoginRequiredProvider>
   );
 };

--- a/src/features/dashboard/components/NoticeCard.tsx
+++ b/src/features/dashboard/components/NoticeCard.tsx
@@ -28,6 +28,13 @@ export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
   const [isBookmarked, setIsBookmarked] = useState(
     Boolean(notice.isBookmarked),
   );
+  // 외부(리스트 리패치 등)에서 notice.isBookmarked가 바뀌면 로컬 상태를 동기화한다.
+  // (React 권장 render-phase 동기화 패턴 — 같은 카드 인스턴스가 재사용될 때 stale 방지)
+  const [prevIsBookmarked, setPrevIsBookmarked] = useState(notice.isBookmarked);
+  if (notice.isBookmarked !== prevIsBookmarked) {
+    setPrevIsBookmarked(notice.isBookmarked);
+    setIsBookmarked(Boolean(notice.isBookmarked));
+  }
   const showDeadlineBadge = isDeadlineSoon(notice) || isDeadlinePassed(notice);
   const deadlineBadgeLabel = getDeadlineBadgeLabel(notice);
   const thumbnailUrl = toBackendAssetUrl(notice.thumbnailUrl);

--- a/src/features/dashboard/components/NoticeCard.tsx
+++ b/src/features/dashboard/components/NoticeCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
 import { Bookmark, Clock } from "lucide-react";
 import { ROUTES } from "../../../app/router/paths";
@@ -22,6 +22,7 @@ interface NoticeCardProps {
 
 export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const [isBookmarked, setIsBookmarked] = useState(
     Boolean(notice.isBookmarked),
@@ -33,7 +34,12 @@ export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
   const bookmarkMutation = useMutation({
     mutationFn: (next: boolean) =>
       next ? addBookmark(Number(notice.id)) : removeBookmark(Number(notice.id)),
-    onSuccess: (status) => setIsBookmarked(status.bookmarked),
+    onSuccess: (status) => {
+      setIsBookmarked(status.bookmarked);
+      // 북마크 목록/공지 목록 캐시를 무효화해 즉시 반영되게 한다.
+      queryClient.invalidateQueries({ queryKey: ["bookmarked-notices"] });
+      queryClient.invalidateQueries({ queryKey: ["notices"] });
+    },
     onError: (error, next) => {
       setIsBookmarked(!next); // 낙관적 토글 되돌리기
       const apiError = toApiClientError(error);

--- a/src/features/dashboard/components/NoticeCard.tsx
+++ b/src/features/dashboard/components/NoticeCard.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { Bookmark, Clock } from "lucide-react";
 import { ROUTES } from "../../../app/router/paths";
 import { addBookmark, removeBookmark } from "../../../shared/api/bookmark";
 import { toApiClientError } from "../../../shared/api/client";
+import { useLoginRequired } from "../../../shared/hooks/useLoginRequired";
 import { useAuth } from "../../../shared/hooks/useAuth";
 import { toBackendAssetUrl } from "../../../shared/utils/assets";
 import type { NoticeCardData } from "../types/notice";
@@ -21,7 +22,7 @@ interface NoticeCardProps {
 }
 
 export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
-  const navigate = useNavigate();
+  const requireLogin = useLoginRequired();
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const [isBookmarked, setIsBookmarked] = useState(
@@ -44,7 +45,7 @@ export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
       setIsBookmarked(!next); // 낙관적 토글 되돌리기
       const apiError = toApiClientError(error);
       if (apiError.status === 401) {
-        navigate(ROUTES.login);
+        requireLogin();
       }
     },
   });
@@ -53,7 +54,7 @@ export const NoticeCard = ({ notice, departmentId }: NoticeCardProps) => {
     event.preventDefault();
     event.stopPropagation();
     if (!isAuthenticated) {
-      navigate(ROUTES.login);
+      requireLogin();
       return;
     }
     if (bookmarkMutation.isPending) return;

--- a/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
+++ b/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import {
   Bookmark,
@@ -27,6 +27,7 @@ interface NoticeDetailSidebarProps {
 
 export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const [bookmarkState, setBookmarkState] = useState({
     noticeId: notice.id,
@@ -46,6 +47,9 @@ export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
         noticeId: notice.id,
         isBookmarked: status.bookmarked,
       });
+      // 북마크 목록/공지 목록 캐시를 무효화해 즉시 반영되게 한다.
+      queryClient.invalidateQueries({ queryKey: ["bookmarked-notices"] });
+      queryClient.invalidateQueries({ queryKey: ["notices"] });
     },
     onError: (error, next) => {
       // 실패 시 낙관적 토글 되돌리기

--- a/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
+++ b/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
@@ -32,11 +32,24 @@ export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
     noticeId: notice.id,
     isBookmarked: notice.isBookmarked,
   });
+  // prop 변경(공지 전환 또는 외부 리패치로 isBookmarked 변경) 시 로컬 상태 동기화한다.
+  // (React 권장 render-phase 동기화 패턴 — 같은 컴포넌트 인스턴스가 재사용될 때 stale 방지)
+  const [prevNotice, setPrevNotice] = useState({
+    id: notice.id,
+    isBookmarked: notice.isBookmarked,
+  });
+  if (
+    notice.id !== prevNotice.id ||
+    notice.isBookmarked !== prevNotice.isBookmarked
+  ) {
+    setPrevNotice({ id: notice.id, isBookmarked: notice.isBookmarked });
+    setBookmarkState({
+      noticeId: notice.id,
+      isBookmarked: notice.isBookmarked,
+    });
+  }
   const attachments = buildVisibleAttachments(notice.attachments);
-  const isBookmarked =
-    bookmarkState.noticeId === notice.id
-      ? bookmarkState.isBookmarked
-      : notice.isBookmarked;
+  const isBookmarked = bookmarkState.isBookmarked;
 
   const bookmarkMutation = useMutation({
     mutationFn: (next: boolean) =>

--- a/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
+++ b/src/features/noticeDetail/components/NoticeDetailSidebar.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
 import {
   Bookmark,
   Calendar,
@@ -17,8 +16,8 @@ import type { ReactNode } from "react";
 import { toBackendAssetUrl } from "../../../shared/utils/assets";
 import { addBookmark, removeBookmark } from "../../../shared/api/bookmark";
 import { toApiClientError } from "../../../shared/api/client";
+import { useLoginRequired } from "../../../shared/hooks/useLoginRequired";
 import { useAuth } from "../../../shared/hooks/useAuth";
-import { ROUTES } from "../../../app/router/paths";
 import type { NoticeAttachmentData, NoticeDetailData } from "../types";
 
 interface NoticeDetailSidebarProps {
@@ -26,7 +25,7 @@ interface NoticeDetailSidebarProps {
 }
 
 export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
-  const navigate = useNavigate();
+  const requireLogin = useLoginRequired();
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const [bookmarkState, setBookmarkState] = useState({
@@ -56,7 +55,7 @@ export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
       setBookmarkState({ noticeId: notice.id, isBookmarked: !next });
       const apiError = toApiClientError(error);
       if (apiError.status === 401) {
-        navigate(ROUTES.login);
+        requireLogin();
         return;
       }
       window.alert(apiError.message);
@@ -65,7 +64,7 @@ export const NoticeDetailSidebar = ({ notice }: NoticeDetailSidebarProps) => {
 
   const handleBookmarkToggle = () => {
     if (!isAuthenticated) {
-      navigate(ROUTES.login);
+      requireLogin();
       return;
     }
     if (bookmarkMutation.isPending) {

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -591,331 +591,363 @@ export const MyPage = () => {
         </section>
 
         {isEditingProfile && (
-          <section className="mt-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] sm:p-6">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h2 className="text-lg font-bold text-slate-950">
-                  내 정보 수정
-                </h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  마이페이지와 공지 개인화에 사용할 정보를 수정합니다.
-                </p>
-              </div>
-
-              <button
-                aria-label="내 정보 수정 닫기"
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
-                onClick={closeProfileEditForm}
-                type="button"
-              >
-                <X
-                  aria-hidden="true"
-                  className="h-4 w-4"
-                />
-              </button>
-            </div>
-
-            <form
-              className="mt-5 space-y-5"
-              noValidate
-              onSubmit={handleProfileEditSubmit}
+          <div
+            className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/60 px-5 py-8 backdrop-blur-sm"
+            onClick={closeProfileEditForm}
+          >
+            <section
+              className="my-auto w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_24px_80px_rgba(15,23,42,0.28)] sm:p-6"
+              onClick={(event) => event.stopPropagation()}
+              role="dialog"
+              aria-modal="true"
             >
-              <div>
-                <label
-                  className="text-sm font-bold text-slate-700"
-                  htmlFor="profile-nickname"
-                >
-                  닉네임
-                </label>
-                <input
-                  className="mt-2 h-12 w-full rounded-xl border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-950 transition outline-none placeholder:text-slate-400 focus:border-[#2046FF] focus:ring-4 focus:ring-[#2046FF]/10"
-                  id="profile-nickname"
-                  maxLength={MAX_NICKNAME_LENGTH}
-                  onChange={(event) => {
-                    setEditForm((form) => ({
-                      ...form,
-                      nickname: event.target.value,
-                    }));
-                    setEditErrorMessage("");
-                  }}
-                  placeholder="닉네임을 입력해주세요"
-                  type="text"
-                  value={editForm.nickname}
-                />
-                <div className="mt-2 flex justify-end text-xs font-semibold text-slate-400">
-                  {editForm.nickname.length}/{MAX_NICKNAME_LENGTH}
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-lg font-bold text-slate-950">
+                    내 정보 수정
+                  </h2>
+                  <p className="mt-1 text-sm text-slate-500">
+                    마이페이지와 공지 개인화에 사용할 정보를 수정합니다.
+                  </p>
                 </div>
-              </div>
 
-              <div>
-                <p className="text-sm font-bold text-slate-700">학과</p>
-                <div className="mt-2 grid gap-2 sm:grid-cols-2">
-                  {DEPARTMENTS.map((department) => {
-                    const isSelected =
-                      department.backendDeptCode === editForm.department;
-
-                    return (
-                      <button
-                        className={`flex h-12 items-center justify-between rounded-xl border px-4 text-left text-sm font-bold transition ${
-                          isSelected
-                            ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
-                            : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
-                        }`}
-                        key={department.id}
-                        onClick={() => {
-                          setEditForm((form) => ({
-                            ...form,
-                            department: department.backendDeptCode,
-                          }));
-                          setEditErrorMessage("");
-                        }}
-                        type="button"
-                      >
-                        {department.name}
-                        {isSelected && (
-                          <span className="h-2 w-2 rounded-full bg-[#2046FF]" />
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <p className="text-sm font-bold text-slate-700">학년</p>
-                <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-5">
-                  {gradeOptions.map((option) => {
-                    const isSelected = option.value === editForm.grade;
-
-                    return (
-                      <button
-                        className={`h-11 rounded-xl border px-3 text-sm font-bold transition ${
-                          isSelected
-                            ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
-                            : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
-                        }`}
-                        key={option.value}
-                        onClick={() => {
-                          setEditForm((form) => ({
-                            ...form,
-                            grade: option.value,
-                          }));
-                          setEditErrorMessage("");
-                        }}
-                        type="button"
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div className="rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-500">
-                선택 정보:{" "}
-                <span className="font-bold text-slate-800">
-                  {selectedEditDepartment?.name || "학과 미선택"} ·{" "}
-                  {editForm.grade ? formatGrade(editForm.grade) : "학년 미선택"}
-                </span>
-              </div>
-
-              {editErrorMessage && (
-                <div className="flex items-start gap-2 rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-600">
-                  <AlertCircle
-                    aria-hidden="true"
-                    className="mt-0.5 h-4 w-4 shrink-0"
-                  />
-                  {editErrorMessage}
-                </div>
-              )}
-
-              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
                 <button
-                  className="h-11 rounded-xl bg-slate-100 px-5 text-sm font-bold text-slate-700 transition hover:bg-slate-200"
+                  aria-label="내 정보 수정 닫기"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
                   onClick={closeProfileEditForm}
                   type="button"
                 >
-                  취소
-                </button>
-                <button
-                  className="h-11 rounded-xl bg-[#2046FF] px-5 text-sm font-bold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
-                  disabled={!canSubmitProfileEdit}
-                  type="submit"
-                >
-                  {isSavingProfile ? "저장 중" : "저장"}
+                  <X
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                  />
                 </button>
               </div>
-            </form>
-          </section>
+
+              <form
+                className="mt-5 space-y-5"
+                noValidate
+                onSubmit={handleProfileEditSubmit}
+              >
+                <div>
+                  <label
+                    className="text-sm font-bold text-slate-700"
+                    htmlFor="profile-nickname"
+                  >
+                    닉네임
+                  </label>
+                  <input
+                    className="mt-2 h-12 w-full rounded-xl border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-950 transition outline-none placeholder:text-slate-400 focus:border-[#2046FF] focus:ring-4 focus:ring-[#2046FF]/10"
+                    id="profile-nickname"
+                    maxLength={MAX_NICKNAME_LENGTH}
+                    onChange={(event) => {
+                      setEditForm((form) => ({
+                        ...form,
+                        nickname: event.target.value,
+                      }));
+                      setEditErrorMessage("");
+                    }}
+                    placeholder="닉네임을 입력해주세요"
+                    type="text"
+                    value={editForm.nickname}
+                  />
+                  <div className="mt-2 flex justify-end text-xs font-semibold text-slate-400">
+                    {editForm.nickname.length}/{MAX_NICKNAME_LENGTH}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-sm font-bold text-slate-700">학과</p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    {DEPARTMENTS.map((department) => {
+                      const isSelected =
+                        department.backendDeptCode === editForm.department;
+
+                      return (
+                        <button
+                          className={`flex h-12 items-center justify-between rounded-xl border px-4 text-left text-sm font-bold transition ${
+                            isSelected
+                              ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
+                              : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                          }`}
+                          key={department.id}
+                          onClick={() => {
+                            setEditForm((form) => ({
+                              ...form,
+                              department: department.backendDeptCode,
+                            }));
+                            setEditErrorMessage("");
+                          }}
+                          type="button"
+                        >
+                          {department.name}
+                          {isSelected && (
+                            <span className="h-2 w-2 rounded-full bg-[#2046FF]" />
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-sm font-bold text-slate-700">학년</p>
+                  <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-5">
+                    {gradeOptions.map((option) => {
+                      const isSelected = option.value === editForm.grade;
+
+                      return (
+                        <button
+                          className={`h-11 rounded-xl border px-3 text-sm font-bold transition ${
+                            isSelected
+                              ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
+                              : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                          }`}
+                          key={option.value}
+                          onClick={() => {
+                            setEditForm((form) => ({
+                              ...form,
+                              grade: option.value,
+                            }));
+                            setEditErrorMessage("");
+                          }}
+                          type="button"
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-500">
+                  선택 정보:{" "}
+                  <span className="font-bold text-slate-800">
+                    {selectedEditDepartment?.name || "학과 미선택"} ·{" "}
+                    {editForm.grade
+                      ? formatGrade(editForm.grade)
+                      : "학년 미선택"}
+                  </span>
+                </div>
+
+                {editErrorMessage && (
+                  <div className="flex items-start gap-2 rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-600">
+                    <AlertCircle
+                      aria-hidden="true"
+                      className="mt-0.5 h-4 w-4 shrink-0"
+                    />
+                    {editErrorMessage}
+                  </div>
+                )}
+
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <button
+                    className="h-11 rounded-xl bg-slate-100 px-5 text-sm font-bold text-slate-700 transition hover:bg-slate-200"
+                    onClick={closeProfileEditForm}
+                    type="button"
+                  >
+                    취소
+                  </button>
+                  <button
+                    className="h-11 rounded-xl bg-[#2046FF] px-5 text-sm font-bold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
+                    disabled={!canSubmitProfileEdit}
+                    type="submit"
+                  >
+                    {isSavingProfile ? "저장 중" : "저장"}
+                  </button>
+                </div>
+              </form>
+            </section>
+          </div>
         )}
 
         {isChangingPassword && (
-          <section className="mt-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] sm:p-6">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h2 className="text-lg font-bold text-slate-950">
-                  비밀번호 변경
-                </h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다.
-                </p>
-              </div>
-
-              <button
-                aria-label="비밀번호 변경 닫기"
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
-                onClick={closePasswordChangeForm}
-                type="button"
-              >
-                <X
-                  aria-hidden="true"
-                  className="h-4 w-4"
-                />
-              </button>
-            </div>
-
-            <form
-              className="mt-5 space-y-5"
-              noValidate
-              onSubmit={handlePasswordChangeSubmit}
+          <div
+            className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/60 px-5 py-8 backdrop-blur-sm"
+            onClick={closePasswordChangeForm}
+          >
+            <section
+              className="my-auto w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_24px_80px_rgba(15,23,42,0.28)] sm:p-6"
+              onClick={(event) => event.stopPropagation()}
+              role="dialog"
+              aria-modal="true"
             >
-              <PasswordField
-                autoComplete="current-password"
-                id="current-password"
-                label="현재 비밀번호"
-                onChange={(value) => {
-                  setPasswordForm((form) => ({
-                    ...form,
-                    currentPassword: value,
-                  }));
-                  setPasswordErrorMessage("");
-                }}
-                placeholder="현재 비밀번호 입력"
-                value={passwordForm.currentPassword}
-              />
-
-              <PasswordField
-                autoComplete="new-password"
-                id="new-password"
-                label="새 비밀번호"
-                onChange={(value) => {
-                  setPasswordForm((form) => ({
-                    ...form,
-                    newPassword: value,
-                  }));
-                  setPasswordErrorMessage("");
-                }}
-                placeholder="영문+숫자 포함 8자 이상"
-                value={passwordForm.newPassword}
-              />
-
-              <PasswordField
-                autoComplete="new-password"
-                id="new-password-confirm"
-                label="새 비밀번호 확인"
-                onChange={(value) => {
-                  setPasswordForm((form) => ({
-                    ...form,
-                    newPasswordConfirm: value,
-                  }));
-                  setPasswordErrorMessage("");
-                }}
-                placeholder="새 비밀번호 재입력"
-                value={passwordForm.newPasswordConfirm}
-              />
-
-              <div className="rounded-xl bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-500">
-                새 비밀번호는 영문과 숫자를 모두 포함해 8자 이상이어야 합니다.
-              </div>
-
-              {passwordErrorMessage && (
-                <div className="flex items-start gap-2 rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-600">
-                  <AlertCircle
-                    aria-hidden="true"
-                    className="mt-0.5 h-4 w-4 shrink-0"
-                  />
-                  {passwordErrorMessage}
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-lg font-bold text-slate-950">
+                    비밀번호 변경
+                  </h2>
+                  <p className="mt-1 text-sm text-slate-500">
+                    현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다.
+                  </p>
                 </div>
-              )}
 
-              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
                 <button
-                  className="h-11 rounded-xl bg-slate-100 px-5 text-sm font-bold text-slate-700 transition hover:bg-slate-200"
+                  aria-label="비밀번호 변경 닫기"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
                   onClick={closePasswordChangeForm}
                   type="button"
                 >
-                  취소
-                </button>
-                <button
-                  className="h-11 rounded-xl bg-[#2046FF] px-5 text-sm font-bold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
-                  disabled={!canSubmitPasswordChange}
-                  type="submit"
-                >
-                  {isSavingPassword ? "변경 중" : "변경"}
+                  <X
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                  />
                 </button>
               </div>
-            </form>
-          </section>
+
+              <form
+                className="mt-5 space-y-5"
+                noValidate
+                onSubmit={handlePasswordChangeSubmit}
+              >
+                <PasswordField
+                  autoComplete="current-password"
+                  id="current-password"
+                  label="현재 비밀번호"
+                  onChange={(value) => {
+                    setPasswordForm((form) => ({
+                      ...form,
+                      currentPassword: value,
+                    }));
+                    setPasswordErrorMessage("");
+                  }}
+                  placeholder="현재 비밀번호 입력"
+                  value={passwordForm.currentPassword}
+                />
+
+                <PasswordField
+                  autoComplete="new-password"
+                  id="new-password"
+                  label="새 비밀번호"
+                  onChange={(value) => {
+                    setPasswordForm((form) => ({
+                      ...form,
+                      newPassword: value,
+                    }));
+                    setPasswordErrorMessage("");
+                  }}
+                  placeholder="영문+숫자 포함 8자 이상"
+                  value={passwordForm.newPassword}
+                />
+
+                <PasswordField
+                  autoComplete="new-password"
+                  id="new-password-confirm"
+                  label="새 비밀번호 확인"
+                  onChange={(value) => {
+                    setPasswordForm((form) => ({
+                      ...form,
+                      newPasswordConfirm: value,
+                    }));
+                    setPasswordErrorMessage("");
+                  }}
+                  placeholder="새 비밀번호 재입력"
+                  value={passwordForm.newPasswordConfirm}
+                />
+
+                <div className="rounded-xl bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-500">
+                  새 비밀번호는 영문과 숫자를 모두 포함해 8자 이상이어야 합니다.
+                </div>
+
+                {passwordErrorMessage && (
+                  <div className="flex items-start gap-2 rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-600">
+                    <AlertCircle
+                      aria-hidden="true"
+                      className="mt-0.5 h-4 w-4 shrink-0"
+                    />
+                    {passwordErrorMessage}
+                  </div>
+                )}
+
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <button
+                    className="h-11 rounded-xl bg-slate-100 px-5 text-sm font-bold text-slate-700 transition hover:bg-slate-200"
+                    onClick={closePasswordChangeForm}
+                    type="button"
+                  >
+                    취소
+                  </button>
+                  <button
+                    className="h-11 rounded-xl bg-[#2046FF] px-5 text-sm font-bold text-white transition hover:bg-[#1838d8] disabled:cursor-not-allowed disabled:bg-slate-300"
+                    disabled={!canSubmitPasswordChange}
+                    type="submit"
+                  >
+                    {isSavingPassword ? "변경 중" : "변경"}
+                  </button>
+                </div>
+              </form>
+            </section>
+          </div>
         )}
 
         {isEditingDefaultDept && (
-          <section className="mt-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] sm:p-6">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h2 className="text-lg font-bold text-slate-950">
-                  기본 학과 설정
-                </h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  앱에 처음 들어왔을 때 보여줄 공지 학과를 선택합니다. 선택 즉시
-                  저장됩니다.
-                </p>
+          <div
+            className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/60 px-5 py-8 backdrop-blur-sm"
+            onClick={() => setIsEditingDefaultDept(false)}
+          >
+            <section
+              className="my-auto w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_24px_80px_rgba(15,23,42,0.28)] sm:p-6"
+              onClick={(event) => event.stopPropagation()}
+              role="dialog"
+              aria-modal="true"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-lg font-bold text-slate-950">
+                    기본 학과 설정
+                  </h2>
+                  <p className="mt-1 text-sm text-slate-500">
+                    앱에 처음 들어왔을 때 보여줄 공지 학과를 선택합니다. 선택
+                    즉시 저장됩니다.
+                  </p>
+                </div>
+
+                <button
+                  aria-label="기본 학과 설정 닫기"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
+                  onClick={() => setIsEditingDefaultDept(false)}
+                  type="button"
+                >
+                  <X
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                  />
+                </button>
               </div>
 
-              <button
-                aria-label="기본 학과 설정 닫기"
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100"
-                onClick={() => setIsEditingDefaultDept(false)}
-                type="button"
-              >
-                <X
-                  aria-hidden="true"
-                  className="h-4 w-4"
-                />
-              </button>
-            </div>
+              <div className="mt-5 grid gap-2 sm:grid-cols-2">
+                {DEPARTMENTS.map((department) => {
+                  const isSelected = department.id === defaultDeptId;
 
-            <div className="mt-5 grid gap-2 sm:grid-cols-2">
-              {DEPARTMENTS.map((department) => {
-                const isSelected = department.id === defaultDeptId;
+                  return (
+                    <button
+                      className={`flex h-12 items-center justify-between rounded-xl border px-4 text-left text-sm font-bold transition ${
+                        isSelected
+                          ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
+                          : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+                      }`}
+                      key={department.id}
+                      onClick={() => handleSelectDefaultDept(department.id)}
+                      type="button"
+                    >
+                      {department.name}
+                      {isSelected && (
+                        <span className="h-2 w-2 rounded-full bg-[#2046FF]" />
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
 
-                return (
-                  <button
-                    className={`flex h-12 items-center justify-between rounded-xl border px-4 text-left text-sm font-bold transition ${
-                      isSelected
-                        ? "border-[#2046FF] bg-[#2046FF]/5 text-[#2046FF]"
-                        : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
-                    }`}
-                    key={department.id}
-                    onClick={() => handleSelectDefaultDept(department.id)}
-                    type="button"
-                  >
-                    {department.name}
-                    {isSelected && (
-                      <span className="h-2 w-2 rounded-full bg-[#2046FF]" />
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-
-            <div className="mt-4 rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-500">
-              현재 기본 학과:{" "}
-              <span className="font-bold text-slate-800">
-                {DEPARTMENTS.find((dept) => dept.id === defaultDeptId)?.name ??
-                  "기본값 (소프트웨어학과)"}
-              </span>
-            </div>
-          </section>
+              <div className="mt-4 rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-500">
+                현재 기본 학과:{" "}
+                <span className="font-bold text-slate-800">
+                  {DEPARTMENTS.find((dept) => dept.id === defaultDeptId)
+                    ?.name ?? "기본값 (소프트웨어학과)"}
+                </span>
+              </div>
+            </section>
+          </div>
         )}
 
         <div className="mt-5 space-y-4">

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -45,6 +45,7 @@ import {
   getPreferredDepartmentId,
   setPreferredDepartmentId,
 } from "../../shared/hooks/usePreferredDepartment";
+import { useEscapeKey } from "../../shared/hooks/useEscapeKey";
 
 type MenuItem = {
   title: string;
@@ -322,6 +323,24 @@ export const MyPage = () => {
     setIsDeletingAccount(false);
     setAccountDeleteErrorMessage("");
   };
+
+  // Esc 키로 현재 열린 모달을 닫는다.
+  const isAnyModalOpen =
+    isEditingProfile ||
+    isChangingPassword ||
+    isEditingDefaultDept ||
+    isDeletingAccount;
+  useEscapeKey(() => {
+    if (isEditingProfile) {
+      closeProfileEditForm();
+    } else if (isChangingPassword) {
+      closePasswordChangeForm();
+    } else if (isEditingDefaultDept) {
+      setIsEditingDefaultDept(false);
+    } else if (isDeletingAccount) {
+      closeAccountDeleteForm();
+    }
+  }, isAnyModalOpen);
 
   const handleProfileEditSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/shared/components/LoginRequiredModal.tsx
+++ b/src/shared/components/LoginRequiredModal.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { LogIn, X } from "lucide-react";
 import { ROUTES } from "../../app/router/paths";
 import { LoginRequiredContext } from "../hooks/useLoginRequired";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 
 export const LoginRequiredProvider = ({ children }: PropsWithChildren) => {
   const [open, setOpen] = useState(false);
@@ -26,6 +27,8 @@ interface LoginRequiredModalProps {
 
 const LoginRequiredModal = ({ open, onClose }: LoginRequiredModalProps) => {
   const navigate = useNavigate();
+
+  useEscapeKey(onClose, open);
 
   if (!open) {
     return null;

--- a/src/shared/components/LoginRequiredModal.tsx
+++ b/src/shared/components/LoginRequiredModal.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useState, type PropsWithChildren } from "react";
+import { useNavigate } from "react-router-dom";
+import { LogIn, X } from "lucide-react";
+import { ROUTES } from "../../app/router/paths";
+import { LoginRequiredContext } from "../hooks/useLoginRequired";
+
+export const LoginRequiredProvider = ({ children }: PropsWithChildren) => {
+  const [open, setOpen] = useState(false);
+  const requireLogin = useCallback(() => setOpen(true), []);
+
+  return (
+    <LoginRequiredContext.Provider value={requireLogin}>
+      {children}
+      <LoginRequiredModal
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </LoginRequiredContext.Provider>
+  );
+};
+
+interface LoginRequiredModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const LoginRequiredModal = ({ open, onClose }: LoginRequiredModalProps) => {
+  const navigate = useNavigate();
+
+  if (!open) {
+    return null;
+  }
+
+  const goLogin = () => {
+    onClose();
+    navigate(ROUTES.login);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-slate-950/60 px-5 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <section
+        aria-labelledby="login-required-title"
+        aria-modal="true"
+        className="w-full max-w-sm rounded-2xl bg-white p-6 text-center shadow-[0_24px_80px_rgba(15,23,42,0.28)]"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <div className="flex justify-end">
+          <button
+            aria-label="닫기"
+            className="flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-100"
+            onClick={onClose}
+            type="button"
+          >
+            <X
+              aria-hidden="true"
+              className="h-4 w-4"
+            />
+          </button>
+        </div>
+
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-[#2046FF]/10 text-[#2046FF]">
+          <LogIn
+            aria-hidden="true"
+            className="h-7 w-7"
+          />
+        </div>
+
+        <h2
+          className="text-lg font-bold text-slate-900"
+          id="login-required-title"
+        >
+          로그인이 필요한 서비스입니다
+        </h2>
+        <p className="mt-2 text-sm text-slate-500">
+          로그인하면 공지를 북마크하고 마이페이지에서 모아볼 수 있습니다.
+        </p>
+
+        <div className="mt-6 flex flex-col gap-2">
+          <button
+            className="h-11 rounded-xl bg-[#2046FF] px-5 text-sm font-bold text-white transition hover:bg-[#1838d8]"
+            onClick={goLogin}
+            type="button"
+          >
+            로그인 하기
+          </button>
+          <button
+            className="h-11 rounded-xl bg-slate-100 px-5 text-sm font-bold text-slate-600 transition hover:bg-slate-200"
+            onClick={onClose}
+            type="button"
+          >
+            닫기
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/shared/hooks/useEscapeKey.ts
+++ b/src/shared/hooks/useEscapeKey.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/**
+ * enabled가 true인 동안 Esc 키를 누르면 onEscape를 호출한다. (모달 닫기용)
+ */
+export const useEscapeKey = (onEscape: () => void, enabled = true) => {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onEscape();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onEscape, enabled]);
+};

--- a/src/shared/hooks/useLoginRequired.ts
+++ b/src/shared/hooks/useLoginRequired.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export type RequireLogin = () => void;
+
+export const LoginRequiredContext = createContext<RequireLogin>(() => {});
+
+/**
+ * 로그인이 필요한 동작(예: 북마크)에서 호출하면 "로그인이 필요한 서비스입니다"
+ * 모달을 띄운다. LoginRequiredProvider 하위 어디서든 사용할 수 있다.
+ */
+export const useLoginRequired = () => useContext(LoginRequiredContext);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #83

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

**1. 북마크 즉시 반영 (버그 수정)**
- 북마크 토글 성공 시 `["bookmarked-notices"]`, `["notices"]` 쿼리 invalidate → 새로고침 없이 즉시 반영

**2. 로그인 필요 모달 (UX 개선)**
- 미로그인 사용자가 북마크 클릭 시 즉시 로그인 페이지로 보내지 않고, "로그인이 필요한 서비스입니다" 모달 표시 (로그인 하기 / 닫기)
- `LoginRequiredProvider` + `useLoginRequired()` 컨텍스트로 앱 전역에서 호출

**3. 마이페이지 설정 모달화 (UX 개선)**
- 내 정보 수정 / 비밀번호 변경 / 기본 학과 설정을 인라인 섹션 → 모달로 전환
- 기존엔 설정 영역이 메뉴 위에 생겨 스크롤이 필요했으나, 화면 중앙 모달로 개선

## 📎 기타 참고사항

- 로컬 검증: tsc / eslint / prettier / build 전부 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로그인이 필요한 작업 시 모달 창이 표시됩니다.
  * 모달을 Escape 키로 닫을 수 있습니다.
  * 마이페이지 모달이 전체 화면 오버레이 형식으로 개선되었습니다.

* **버그 수정**
  * 북마크 상태가 외부 변경 시 실시간으로 동기화됩니다.
  * 캐시 무효화를 통해 북마크 변경사항이 즉시 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->