### PR TITLE
Fix(#85): 마이페이지 닉네임 헤더 동기화

### DIFF
--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -152,7 +152,7 @@ const initialAccountDeleteForm: AccountDeleteForm = {
 
 export const MyPage = () => {
   const navigate = useNavigate();
-  const { logout, userName, username } = useAuth();
+  const { logout, updateUserName, userName, username } = useAuth();
   const profileDraft = useMemo(() => getOnboardingProfileDraft(), []);
   const [profile, setProfile] = useState<UserProfileResponse | null>(null);
   const [isProfileLoading, setIsProfileLoading] = useState(true);
@@ -362,6 +362,7 @@ export const MyPage = () => {
       });
 
       setProfile(updatedProfile);
+      updateUserName(updatedProfile.nickname);
 
       const updatedDepartmentId = getDepartmentIdByCode(
         updatedProfile.department,

--- a/src/shared/hooks/useAuth.ts
+++ b/src/shared/hooks/useAuth.ts
@@ -20,6 +20,18 @@ export const setAccessToken = (token: string) => {
   notifyAuthChanged();
 };
 
+export const setStoredUserName = (name: string) => {
+  const normalizedName = name.trim();
+
+  if (normalizedName) {
+    localStorage.setItem(USER_NAME_KEY, normalizedName);
+  } else {
+    localStorage.removeItem(USER_NAME_KEY);
+  }
+
+  notifyAuthChanged();
+};
+
 export const clearAuthStorage = () => {
   const hasAuthStorage =
     localStorage.getItem(ACCESS_TOKEN_KEY) ||
@@ -102,7 +114,15 @@ export const useAuth = () => {
   }, []);
 
   return useMemo(
-    () => ({ isAuthenticated, userName, username, role, login, logout }),
+    () => ({
+      isAuthenticated,
+      userName,
+      username,
+      role,
+      login,
+      logout,
+      updateUserName: setStoredUserName,
+    }),
     [isAuthenticated, userName, username, role, login, logout],
   );
 };


### PR DESCRIPTION
## 관련 이슈

- Closes #85

## PR 타입

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가 (Test)
- [ ] 프로젝트 초기 설정 (Chore)
- [ ] 문서 수정 (Documentation)
- [ ] PR 복구 (Revert)

## 작업 내용

- auth storage의 사용자 표시 이름을 갱신하는 `updateUserName` 함수를 추가했습니다.
- 마이페이지 프로필 수정 성공 시 변경된 닉네임을 auth storage에 반영하도록 연결했습니다.
- `campost-auth-changed` 이벤트를 재사용해 헤더 닉네임이 즉시 갱신되도록 했습니다.

## 스크린샷

- UI 동작 변경: 마이페이지 닉네임 수정 후 헤더 표시명 즉시 반영

## 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 기타 참고사항

- 검증: `pnpm exec tsc -b`
- `pnpm run build`는 로컬 Windows 환경의 Tailwind native binary 로딩 문제로 Vite config 로딩 단계에서 실패했습니다.
